### PR TITLE
Bugfix/transport segments

### DIFF
--- a/include/data/prototype/entity/transport/transport_line.h
+++ b/include/data/prototype/entity/transport/transport_line.h
@@ -236,7 +236,7 @@ namespace jactorio::data
 		}
 
 		void PostLoadValidate() const override {
-			J_DATA_ASSERT(speedFloat > 0.001, "Transport line speed below minimum 0.001");
+			J_DATA_ASSERT(speedFloat >= 0.001, "Transport line speed below minimum 0.001");
 			// Cannot exceed item_width because of limitations in the logic
 			J_DATA_ASSERT(speedFloat < 0.25, "Transport line speed equal or above maximum of 0.25");
 		}

--- a/include/data/prototype/entity/transport/transport_line.h
+++ b/include/data/prototype/entity/transport/transport_line.h
@@ -135,33 +135,6 @@ namespace jactorio::data
 		                                         TransportLineData* c_left,
 		                                         TransportLineData* center);
 
-		// world_x, world_y is the location offset from the original provided as function parameter
-		using UpdateFunc = std::function<
-			void(game::WorldData& world_data,
-			     int world_x,
-			     int world_y,
-			     game::TransportSegment::TerminationType termination_type)>;
-
-		using UpdateSideOnlyFunc = std::function<
-			void(game::WorldData& world_data,
-			     int world_x,
-			     int world_y,
-			     Orientation direction,
-			     game::TransportSegment::TerminationType termination_type)>;
-
-		///
-		/// \brief Calls func or side_only_func depending on the line_orientation, provides parameters on how neighboring lines
-		/// should be modified.
-		/// \remark This does not move across logic chunks and may make the position negative
-		/// \param func Called when line orientation is bending for updating provided line segment
-		/// \param side_only_func Called when line orientation is straight for updating provided line segment 
-		static void UpdateNeighborLines(game::WorldData& world_data,
-		                                int32_t world_x,
-		                                int32_t world_y,
-		                                TransportLineData::LineOrientation line_orientation,
-		                                const UpdateFunc& func,
-		                                const UpdateSideOnlyFunc& side_only_func);
-
 		static void UpdateSegmentHead(game::WorldData& world_data,
 		                              const game::WorldData::WorldPair& world_coords,
 		                              LineData4Way& line_data,

--- a/include/data/prototype/entity/transport/transport_line.h
+++ b/include/data/prototype/entity/transport/transport_line.h
@@ -5,7 +5,6 @@
 #define JACTORIO_INCLUDE_DATA_PROTOTYPE_ENTITY_TRANSPORT_TRANSPORT_LINE_H
 #pragma once
 
-#include <functional>
 #include <memory>
 #include <utility>
 
@@ -118,63 +117,7 @@ namespace jactorio::data
 
 		// ======================================================================
 		// Game events
-	private:
-		static void RemoveFromLogic(game::WorldData& world_data, const game::WorldData::WorldPair& world_coords,
-		                            game::TransportSegment& line_segment);
 
-		/// Up, right, down, left
-		using LineData4Way = TransportLineData*[4];
-
-		///
-		///	\brief Updates the orientation of current and neighboring transport lines 
-		static void UpdateNeighboringOrientation(const game::WorldData& world_data,
-		                                         const game::WorldData::WorldPair& world_coords,
-		                                         TransportLineData* t_center,
-		                                         TransportLineData* c_right,
-		                                         TransportLineData* b_center,
-		                                         TransportLineData* c_left,
-		                                         TransportLineData* center);
-
-		static void UpdateSegmentHead(game::WorldData& world_data,
-		                              const game::WorldData::WorldPair& world_coords,
-		                              LineData4Way& line_data,
-		                              const std::shared_ptr<game::TransportSegment>& line_segment);
-
-		/*
-		 * Transport line grouping rules:
-		 *
-		 * < < < [1, 2, 3] - Direction [order];
-		 * Line ahead:
-		 *		- Extends length of transport line segment
-		 *
-		 * < < < [3, 2, 1]
-		 * Line behind:
-		 *		- Moves head of transport segment, shift leading item 1 tile back
-		 *		
-		 * < < < [1, 3, 2]
-		 * Line ahead and behind:
-		 *		- Behaves as line ahead
-		 */
-
-		///
-		/// \brief Initializes line data and groups transport segments
-		/// Sets the transport segment grouped / newly created with in tile_layer and returns it
-		/// \return Created data for at tile_layer, was a new transport segment created
-		TransportLineData* InitTransportSegment(game::WorldData& world_data,
-		                                        const game::WorldData::WorldPair& world_coords,
-		                                        Orientation orientation,
-		                                        game::ChunkTileLayer& tile_layer,
-		                                        LineData4Way& line_data) const;
-
-		///
-		/// \brief Updates neighboring segments after transport line is removed 
-		/// \param world_coords Coords of transport line removed
-		/// \param line_data Neighboring line segment
-		/// \param target Removed line segment
-		static void DisconnectTargetSegment(game::WorldData& world_data,
-		                                    const game::WorldData::WorldPair& world_coords,
-		                                    TransportLineData* target, TransportLineData* line_data);
-	public:
 		void OnBuild(game::WorldData& world_data,
 		             const game::WorldData::WorldPair& world_coords,
 		             game::ChunkTileLayer& tile_layer,

--- a/include/game/logic/transport_line_controller.h
+++ b/include/game/logic/transport_line_controller.h
@@ -16,6 +16,8 @@ namespace jactorio::game
 	constexpr int kTransportLineDecimalPlace = 3;
 	using TransportLineOffset = dec::decimal<kTransportLineDecimalPlace>;
 
+	// For storing line offsets during transitions, items are treated as having no width
+
 	/* Placement of items on transport line (Expressed as decimal percentages of a tile)
 	 * | R Padding 0.0
 	 * |
@@ -34,13 +36,6 @@ namespace jactorio::game
 	 * With an item_width of 0.4f:
 	 * A right item will occupy the entire space from 0.1 to 0.5
 	 * A left item will occupy the entire space from 0.5 to 0.9
-	 */
-
-	/*
-	 * Item wakeup:
-	 *
-	 * After a transport line lane stops, it cannot wake up by itself, another transport line or lane must call the member update_wakeup
-	 * in transport_line_structure
 	 */
 
 	/// Width of one item on a belt (in tiles)

--- a/include/game/logic/transport_line_controller.h
+++ b/include/game/logic/transport_line_controller.h
@@ -98,6 +98,30 @@ namespace jactorio::game
 	constexpr double kLineDownSingleSideItemOffsetY  = kLineBaseOffsetLeft - kItemWidth / 2;
 	constexpr double kLineLeftSingleSideItemOffsetX  = kLineBaseOffsetRight - kItemWidth / 2;
 
+
+	// When bending, the amounts below are reduced from the distance to the end of the next segment (see diagram below)
+	//
+	// === 0.7 ===
+	// =0.3=
+	//     ------------------------->
+	//     ^         *
+	//     |    -------------------->
+	//     |    ^    *
+	//     |    |    *
+	//     |    |    *
+	// 
+	constexpr double kBendLeftLReduction = 0.7f;
+	constexpr double kBendLeftRReduction = 0.3f;
+
+	constexpr double kBendRightLReduction = 0.3f;
+	constexpr double kBendRightRReduction = 0.7f;
+
+	constexpr double kTargetSideOnlyReduction = 0.7f;
+
+
+	// ======================================================================
+
+
 	///
 	/// \brief Updates belt logic for a logic chunk
 	void TransportLineLogicUpdate(WorldData& world_data);

--- a/include/game/logic/transport_segment.h
+++ b/include/game/logic/transport_segment.h
@@ -76,31 +76,10 @@ namespace jactorio::game
 		using IntOffsetT = TransportLane::IntOffsetT;
 		using FloatOffsetT = TransportLane::FloatOffsetT;
 
-		// When bending, the amounts below are reduced from the distance to the end of the next segment (see diagram below)
-		/*
-		 * === 0.7 ===
-		 * =0.3=
-		 *     ------------------------->
-		 *     ^         *
-		 *     |    -------------------->
-		 *     |    ^    *
-		 *     |    |    *
-		 *     |    |    *
-		 */
-		static constexpr double kBendLeftLReduction = 0.7;
-		static constexpr double kBendLeftRReduction = 0.3;
-
-		static constexpr double kBendRightLReduction = 0.3;
-		static constexpr double kBendRightRReduction = 0.7;
-
 		enum class TerminationType
 		{
 			straight = 0,
-			// Left length -0.7
-			// Right length -0.3
 			bend_left,
-			// Left length -0.3
-			// Right length -0.7
 			bend_right,
 
 			// Left + Right lane -> Left lane

--- a/include/game/logic/transport_segment.h
+++ b/include/game/logic/transport_segment.h
@@ -26,8 +26,8 @@ namespace jactorio::game
 	/// \brief One side of a transport line
 	struct TransportLane
 	{
-		using ItemOffsetT = int16_t;
-		using BeginOffsetT = double;
+		using IntOffsetT = int16_t;
+		using FloatOffsetT = double;
 
 		///
 		/// \return true if left size is not empty and has a valid index
@@ -36,18 +36,18 @@ namespace jactorio::game
 		///
 		/// \param start_offset Item offset from the start of transport line in tiles
 		/// \return true if an item can be inserted into this transport line
-		J_NODISCARD bool CanInsert(TransportLineOffset start_offset, ItemOffsetT item_offset);
+		J_NODISCARD bool CanInsert(TransportLineOffset start_offset, IntOffsetT item_offset);
 
 		// Item insertion 
 		// See TransportSegment for function documentation
 
-		void AppendItem(BeginOffsetT offset, const data::Item* item);
+		void AppendItem(FloatOffsetT offset, const data::Item* item);
 
-		void InsertItem(BeginOffsetT offset, const data::Item* item, ItemOffsetT item_offset);
+		void InsertItem(FloatOffsetT offset, const data::Item* item, IntOffsetT item_offset);
 
-		bool TryInsertItem(BeginOffsetT offset, const data::Item* item, ItemOffsetT item_offset);
+		bool TryInsertItem(FloatOffsetT offset, const data::Item* item, IntOffsetT item_offset);
 
-		const data::Item* TryPopItem(BeginOffsetT offset, BeginOffsetT epsilon = kItemWidth / 2);
+		const data::Item* TryPopItem(FloatOffsetT offset, FloatOffsetT epsilon = kItemWidth / 2);
 
 		// ======================================================================
 
@@ -71,10 +71,10 @@ namespace jactorio::game
 	{
 	private:
 		using SegmentLengthT = uint8_t;
-		using ItemOffsetT = TransportLane::ItemOffsetT;
 
 	public:
-		using BeginOffsetT = TransportLane::BeginOffsetT;
+		using IntOffsetT = TransportLane::IntOffsetT;
+		using FloatOffsetT = TransportLane::FloatOffsetT;
 
 		// When bending, the amounts below are reduced from the distance to the end of the next segment (see diagram below)
 		/*
@@ -145,10 +145,10 @@ namespace jactorio::game
 		/// <br>
 		/// The offset ensures that all entities which stores a segment index tile inserts at the same location
 		/// when the segment is extended or shortened, used in methods with a Abs suffix
-		ItemOffsetT itemOffset = 0;
+		IntOffsetT itemOffset = 0;
 
 		/// If this segment terminates side only, this is the offset from the beginning of target segment to insert at
-		BeginOffsetT targetInsertOffset = 0;
+		IntOffsetT targetInsertOffset = 0;
 
 		// ======================================================================
 
@@ -170,18 +170,18 @@ namespace jactorio::game
 		///
 		/// \brief Appends item onto the specified side of a belt behind the last item
 		/// \param offset Number of tiles to offset from previous item or the end of the transport line segment when there are no items
-		void AppendItem(bool left_side, BeginOffsetT offset, const data::Item* item);
+		void AppendItem(bool left_side, FloatOffsetT offset, const data::Item* item);
 
 		///
 		/// \brief Inserts the item onto the specified belt side at the offset from the beginning of the transport line
 		/// \param offset Distance from beginning of transport line
-		void InsertItem(bool left_side, BeginOffsetT offset, const data::Item* item);
+		void InsertItem(bool left_side, FloatOffsetT offset, const data::Item* item);
 
 		///
 		/// \brief Attempts to insert the item onto the specified belt side at the offset from the beginning of the transport line
 		/// \param offset Distance from beginning of transport line
 		/// \return false if unsuccessful
-		bool TryInsertItem(bool left_side, BeginOffsetT offset, const data::Item* item);
+		bool TryInsertItem(bool left_side, FloatOffsetT offset, const data::Item* item);
 
 
 		// Item insertion with itemOffset
@@ -192,14 +192,14 @@ namespace jactorio::game
 
 		J_NODISCARD bool CanInsertAbs(bool left_side, const TransportLineOffset& start_offset);
 
-		void InsertItemAbs(bool left_side, BeginOffsetT offset, const data::Item* item);
+		void InsertItemAbs(bool left_side, FloatOffsetT offset, const data::Item* item);
 
-		bool TryInsertItemAbs(bool left_side, BeginOffsetT offset, const data::Item* item);
+		bool TryInsertItemAbs(bool left_side, FloatOffsetT offset, const data::Item* item);
 
 		///
 		/// \brief Finds item at offset within epsilon inclusive
 		/// \return nullptr if no items were found
-		const data::Item* TryPopItemAbs(bool left_side, BeginOffsetT offset, BeginOffsetT epsilon = kItemWidth / 2);
+		const data::Item* TryPopItemAbs(bool left_side, FloatOffsetT offset, FloatOffsetT epsilon = kItemWidth / 2);
 
 		///
 		/// \brief Adjusts provided value such that InsertItem(, offset, ) is at the correct location
@@ -209,7 +209,8 @@ namespace jactorio::game
 		/// Thus, an adjustment is applied to all offsets inserting into the segment such that the same offset
 		/// results in the same location regardless of the segment length.
 		/// \param val Distance from beginning of transport segment
-		void GetOffsetAbs(BeginOffsetT& val) const;
+		void GetOffsetAbs(IntOffsetT& val) const;
+		void GetOffsetAbs(FloatOffsetT& val) const;
 	};
 }
 

--- a/src/data/prototype/entity/transport/transport_line.cpp
+++ b/src/data/prototype/entity/transport/transport_line.cpp
@@ -722,6 +722,8 @@ void data::TransportLine::OnBuild(game::WorldData& world_data,
 
 			auto* line_segment = GetTransportSegment(world_data, world_x, world_y);
 			if (line_segment) {
+				line_segment->get()->itemOffset++;
+				
 				line_segment->get()->length++;
 				line_segment->get()->terminationType = termination_type;
 
@@ -801,8 +803,8 @@ void data::TransportLine::OnNeighborUpdate(game::WorldData& world_data,
 	// ======================================================================
 
 	// Reset segment lane item index to 0, since the head items MAY now have somewhere to go
-	line_data->lineSegment.get()->left.index = 0;
-	line_data->lineSegment.get()->right.index = 0;
+	line_data->lineSegment->left.index = 0;
+	line_data->lineSegment->right.index = 0;
 
 	const UpdateFunc func =
 		[](game::WorldData& world_data,
@@ -874,6 +876,7 @@ void data::TransportLine::DisconnectTargetSegment(game::WorldData& world_data,
 		case game::TransportSegment::TerminationType::bend_right:
 		case game::TransportSegment::TerminationType::right_only:
 		case game::TransportSegment::TerminationType::left_only:
+			line_segment->itemOffset--;
 			line_segment->length--;
 			line_segment->terminationType = game::TransportSegment::TerminationType::straight;
 

--- a/src/data/prototype/entity/transport/transport_line.cpp
+++ b/src/data/prototype/entity/transport/transport_line.cpp
@@ -69,6 +69,16 @@ data::Sprite::SetT data::TransportLine::MapPlacementOrientation(const Orientatio
 	return static_cast<uint16_t>(GetLineOrientation(orientation, t_center, c_right, b_center, c_left));
 }
 
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
 // ======================================================================
 // Data access
 
@@ -162,13 +172,13 @@ std::shared_ptr<game::TransportSegment>* data::TransportLine::GetTransportSegmen
 	return nullptr;
 }
 
-void data::TransportLine::RemoveFromLogic(game::WorldData& world_data,
-                                          const game::WorldData::WorldPair& world_coords, game::TransportSegment& line_segment) {
+void RemoveFromLogic(game::WorldData& world_data,
+                     const game::WorldData::WorldPair& world_coords, game::TransportSegment& line_segment) {
 	world_data.LogicRemove(
 		game::Chunk::LogicGroup::transport_line,
 		world_coords,
 		[&](auto* t_layer) {
-			return static_cast<TransportLineData*>(t_layer->GetUniqueData())->lineSegment.get() == &line_segment;
+			return static_cast<data::TransportLineData*>(t_layer->GetUniqueData())->lineSegment.get() == &line_segment;
 		});
 }
 
@@ -191,6 +201,25 @@ void data::TransportLine::RemoveFromLogic(game::WorldData& world_data,
 
 // ======================================================================
 // Build / Remove / Neighbor update
+
+/// Up, right, down, left
+using LineData4Way = data::TransportLineData*[4];
+
+
+///
+/// \brief Applies the necessary adjustments to shift a segment's head forwards or backwards
+/// \tparam Forwards true to shift forwards, false to shift backwards
+template <bool Forwards>
+void ShiftSegmentHead(game::TransportSegment& line_segment) {
+	if constexpr (Forwards) {
+		line_segment.length++;
+		line_segment.itemOffset++;
+	}
+	else {
+		line_segment.length--;
+		line_segment.itemOffset--;
+	}
+}
 
 ///
 /// \brief Updates the world tiles which references a transport segment, props: line_segment_index, line_segment
@@ -225,13 +254,12 @@ void UpdateSegmentTiles(const game::WorldData& world_data,
 	}
 }
 
-void data::TransportLine::UpdateNeighboringOrientation(const game::WorldData& world_data,
-                                                       const game::WorldData::WorldPair& world_coords,
-                                                       TransportLineData* t_center,
-                                                       TransportLineData* c_right,
-                                                       TransportLineData* b_center,
-                                                       TransportLineData* c_left,
-                                                       TransportLineData* center) {
+///
+///	\brief Updates the orientation of current and neighboring transport lines 
+void UpdateNeighborOrientation(const game::WorldData& world_data,
+                               const game::WorldData::WorldPair& world_coords,
+                               LineData4Way line_data_4,
+                               data::TransportLineData* center) {
 	// Building a belt will update all neighboring belts (X), which thus requires tiles (*)
 	/*
 	 *     ---
@@ -246,33 +274,44 @@ void data::TransportLine::UpdateNeighboringOrientation(const game::WorldData& wo
 	 *     |*|        Bottom
 	 *     ---
 	 */
-	auto* top    = GetLineData(world_data, world_coords.first, world_coords.second - 2);
-	auto* right  = GetLineData(world_data, world_coords.first + 2, world_coords.second);
-	auto* bottom = GetLineData(world_data, world_coords.first, world_coords.second + 2);
-	auto* left   = GetLineData(world_data, world_coords.first - 2, world_coords.second);
+	auto* top    = data::TransportLine::GetLineData(world_data, world_coords.first, world_coords.second - 2);
+	auto* right  = data::TransportLine::GetLineData(world_data, world_coords.first + 2, world_coords.second);
+	auto* bottom = data::TransportLine::GetLineData(world_data, world_coords.first, world_coords.second + 2);
+	auto* left   = data::TransportLine::GetLineData(world_data, world_coords.first - 2, world_coords.second);
 
-	auto* t_left  = GetLineData(world_data, world_coords.first - 1, world_coords.second - 1);
-	auto* t_right = GetLineData(world_data, world_coords.first + 1, world_coords.second - 1);
+	auto* t_left  = data::TransportLine::GetLineData(world_data, world_coords.first - 1, world_coords.second - 1);
+	auto* t_right = data::TransportLine::GetLineData(world_data, world_coords.first + 1, world_coords.second - 1);
 
-	auto* b_left  = GetLineData(world_data, world_coords.first - 1, world_coords.second + 1);
-	auto* b_right = GetLineData(world_data, world_coords.first + 1, world_coords.second + 1);
+	auto* b_left  = data::TransportLine::GetLineData(world_data, world_coords.first - 1, world_coords.second + 1);
+	auto* b_right = data::TransportLine::GetLineData(world_data, world_coords.first + 1, world_coords.second + 1);
 
 	// Top neighbor
-	if (t_center)
-		t_center->SetOrientation(
-			GetLineOrientation(TransportLineData::ToOrientation(t_center->orientation), top, t_right, center, t_left));
+	if (line_data_4[0])
+		line_data_4[0]->SetOrientation(
+			data::TransportLine::GetLineOrientation(
+				data::TransportLineData::ToOrientation(line_data_4[0]->orientation),
+				top, t_right, center, t_left)
+		);
 	// Right
-	if (c_right)
-		c_right->SetOrientation(
-			GetLineOrientation(TransportLineData::ToOrientation(c_right->orientation), t_right, right, b_right, center));
+	if (line_data_4[1])
+		line_data_4[1]->SetOrientation(
+			data::TransportLine::GetLineOrientation(data::TransportLineData::ToOrientation(line_data_4[1]->orientation),
+			                                        t_right, right, b_right, center)
+		);
 	// Bottom
-	if (b_center)
-		b_center->SetOrientation(
-			GetLineOrientation(TransportLineData::ToOrientation(b_center->orientation), center, b_right, bottom, b_left));
+	if (line_data_4[2])
+		line_data_4[2]->SetOrientation(
+			data::TransportLine::GetLineOrientation(
+				data::TransportLineData::ToOrientation(line_data_4[2]->orientation),
+				center, b_right, bottom, b_left)
+		);
 	// Left
-	if (c_left)
-		c_left->SetOrientation(
-			GetLineOrientation(TransportLineData::ToOrientation(c_left->orientation), t_left, center, b_left, left));
+	if (line_data_4[3])
+		line_data_4[3]->SetOrientation(
+			data::TransportLine::GetLineOrientation(
+				data::TransportLineData::ToOrientation(line_data_4[3]->orientation),
+				t_left, center, b_left, left)
+		);
 }
 
 ///
@@ -281,20 +320,18 @@ void data::TransportLine::UpdateNeighboringOrientation(const game::WorldData& wo
 /// \tparam IsNeighborUpdate If true, length and itemOffset will also be updated
 /// \remark This does not move across logic chunks and may make the position negative
 template <bool IsNeighborUpdate>
-void UpdateNeighborLines(game::WorldData& world_data,
-                         const game::WorldData::WorldCoord world_x,
-                         const game::WorldData::WorldCoord world_y,
-                         const data::TransportLineData::LineOrientation line_orientation) {
+void UpdateNeighborTermination(game::WorldData& world_data,
+                               const game::WorldData::WorldCoord world_x,
+                               const game::WorldData::WorldCoord world_y,
+                               const data::TransportLineData::LineOrientation line_orientation) {
 
-	auto func = [](game::WorldData& world_data,
-	               int world_x,
-	               int world_y,
-	               const game::TransportSegment::TerminationType termination_type) {
+	auto bend_update = [](game::WorldData& world_data,
+	                      int world_x, int world_y,
+	                      const game::TransportSegment::TerminationType termination_type) {
 		auto* line_segment = data::TransportLine::GetTransportSegment(world_data, world_x, world_y);
 		if (line_segment) {
 			if constexpr (!IsNeighborUpdate) {
-				line_segment->get()->itemOffset++;
-				line_segment->get()->length++;
+				ShiftSegmentHead<true>(**line_segment);
 			}
 			line_segment->get()->terminationType = termination_type;
 
@@ -302,20 +339,19 @@ void UpdateNeighborLines(game::WorldData& world_data,
 		}
 	};
 
-	auto side_only_func = [](game::WorldData& world_data,
-	                         int world_x,
-	                         int world_y,
-	                         const data::Orientation direction,
-	                         const game::TransportSegment::TerminationType termination_type) {
+	auto side_update = [](game::WorldData& world_data,
+	                      int world_x, int world_y,
+	                      const data::Orientation direction,
+	                      const game::TransportSegment::TerminationType termination_type) {
 		auto* line_segment = data::TransportLine::GetTransportSegment(world_data, world_x, world_y);
 		if (line_segment) {
+			// Segment does not match required direction
 			if (line_segment->get()->direction != direction)
 				return;
 
 			if constexpr (!IsNeighborUpdate) {
-				line_segment->get()->length++;
+				ShiftSegmentHead<true>(**line_segment);
 			}
-			line_segment->get()->itemOffset++;  // Offset is incremented by the neighbor
 			line_segment->get()->terminationType = termination_type;
 
 			UpdateSegmentTiles(world_data, {world_x, world_y}, *line_segment, 1);
@@ -325,76 +361,76 @@ void UpdateNeighborLines(game::WorldData& world_data,
 	switch (line_orientation) {
 		// Up
 	case data::TransportLineData::LineOrientation::up_left:
-		func(world_data, world_x, world_y + 1,
-		     game::TransportSegment::TerminationType::bend_left);
+		bend_update(world_data, world_x, world_y + 1,
+		            game::TransportSegment::TerminationType::bend_left);
 		break;
 	case data::TransportLineData::LineOrientation::up_right:
-		func(world_data, world_x, world_y + 1,
-		     game::TransportSegment::TerminationType::bend_right);
+		bend_update(world_data, world_x, world_y + 1,
+		            game::TransportSegment::TerminationType::bend_right);
 		break;
 
 		// Right
 	case data::TransportLineData::LineOrientation::right_up:
-		func(world_data, world_x - 1, world_y,
-		     game::TransportSegment::TerminationType::bend_left);
+		bend_update(world_data, world_x - 1, world_y,
+		            game::TransportSegment::TerminationType::bend_left);
 		break;
 	case data::TransportLineData::LineOrientation::right_down:
-		func(world_data, world_x - 1, world_y,
-		     game::TransportSegment::TerminationType::bend_right);
+		bend_update(world_data, world_x - 1, world_y,
+		            game::TransportSegment::TerminationType::bend_right);
 		break;
 
 		// Down
 	case data::TransportLineData::LineOrientation::down_right:
-		func(world_data, world_x, world_y - 1,
-		     game::TransportSegment::TerminationType::bend_left);
+		bend_update(world_data, world_x, world_y - 1,
+		            game::TransportSegment::TerminationType::bend_left);
 		break;
 	case data::TransportLineData::LineOrientation::down_left:
-		func(world_data, world_x, world_y - 1,
-		     game::TransportSegment::TerminationType::bend_right);
+		bend_update(world_data, world_x, world_y - 1,
+		            game::TransportSegment::TerminationType::bend_right);
 		break;
 
 		// Left
 	case data::TransportLineData::LineOrientation::left_down:
-		func(world_data, world_x + 1, world_y,
-		     game::TransportSegment::TerminationType::bend_left);
+		bend_update(world_data, world_x + 1, world_y,
+		            game::TransportSegment::TerminationType::bend_left);
 		break;
 	case data::TransportLineData::LineOrientation::left_up:
-		func(world_data, world_x + 1, world_y,
-		     game::TransportSegment::TerminationType::bend_right);
+		bend_update(world_data, world_x + 1, world_y,
+		            game::TransportSegment::TerminationType::bend_right);
 		break;
 
 		// Straight (Check for transport lines on both sides to make side only)
 	case data::TransportLineData::LineOrientation::up:
-		side_only_func(world_data, world_x - 1, world_y,
-		               data::Orientation::right,
-		               game::TransportSegment::TerminationType::left_only);
-		side_only_func(world_data, world_x + 1, world_y,
-		               data::Orientation::left,
-		               game::TransportSegment::TerminationType::right_only);
+		side_update(world_data, world_x - 1, world_y,
+		            data::Orientation::right,
+		            game::TransportSegment::TerminationType::left_only);
+		side_update(world_data, world_x + 1, world_y,
+		            data::Orientation::left,
+		            game::TransportSegment::TerminationType::right_only);
 		break;
 	case data::TransportLineData::LineOrientation::right:
-		side_only_func(world_data, world_x, world_y - 1,
-		               data::Orientation::down,
-		               game::TransportSegment::TerminationType::left_only);
-		side_only_func(world_data, world_x, world_y + 1,
-		               data::Orientation::up,
-		               game::TransportSegment::TerminationType::right_only);
+		side_update(world_data, world_x, world_y - 1,
+		            data::Orientation::down,
+		            game::TransportSegment::TerminationType::left_only);
+		side_update(world_data, world_x, world_y + 1,
+		            data::Orientation::up,
+		            game::TransportSegment::TerminationType::right_only);
 		break;
 	case data::TransportLineData::LineOrientation::down:
-		side_only_func(world_data, world_x - 1, world_y,
-		               data::Orientation::right,
-		               game::TransportSegment::TerminationType::right_only);
-		side_only_func(world_data, world_x + 1, world_y,
-		               data::Orientation::left,
-		               game::TransportSegment::TerminationType::left_only);
+		side_update(world_data, world_x - 1, world_y,
+		            data::Orientation::right,
+		            game::TransportSegment::TerminationType::right_only);
+		side_update(world_data, world_x + 1, world_y,
+		            data::Orientation::left,
+		            game::TransportSegment::TerminationType::left_only);
 		break;
 	case data::TransportLineData::LineOrientation::left:
-		side_only_func(world_data, world_x, world_y - 1,
-		               data::Orientation::down,
-		               game::TransportSegment::TerminationType::right_only);
-		side_only_func(world_data, world_x, world_y + 1,
-		               data::Orientation::up,
-		               game::TransportSegment::TerminationType::left_only);
+		side_update(world_data, world_x, world_y - 1,
+		            data::Orientation::down,
+		            game::TransportSegment::TerminationType::right_only);
+		side_update(world_data, world_x, world_y + 1,
+		            data::Orientation::up,
+		            game::TransportSegment::TerminationType::left_only);
 		break;
 
 	default:
@@ -406,23 +442,6 @@ void UpdateNeighborLines(game::WorldData& world_data,
 
 // ======================================================================
 // Build
-
-///
-/// \brief If a transport segment exists at world_x, world_y and has a terminal type == Required,
-/// it will be changed to New
-template <game::TransportSegment::TerminationType Required,
-          game::TransportSegment::TerminationType New>
-void TryChangeTerminationType(const game::WorldData& world_data,
-                              const int32_t world_x, const int32_t world_y) {
-	using namespace jactorio;
-
-	data::TransportLineData* line_data = data::TransportLine::GetLineData(world_data, world_x, world_y);
-	if (line_data) {
-		if (line_data->lineSegment->terminationType == Required) {
-			line_data->lineSegment->terminationType = New;
-		}
-	}
-}
 
 ///
 /// \brief Determines the member target_segment of Transport_line_segment
@@ -471,6 +490,21 @@ void UpdateLineTargets(game::WorldData& world_data,
 }
 
 ///
+/// \brief If a transport segment exists at world_x, world_y and has a terminal type == Required,
+/// it will be changed to New
+template <game::TransportSegment::TerminationType Required,
+          game::TransportSegment::TerminationType New>
+void TryChangeTerminationType(const game::WorldData& world_data,
+                              const int32_t world_x, const int32_t world_y) {
+	data::TransportLineData* line_data = data::TransportLine::GetLineData(world_data, world_x, world_y);
+	if (line_data) {
+		if (line_data->lineSegment->terminationType == Required) {
+			line_data->lineSegment->terminationType = New;
+		}
+	}
+}
+
+///
 /// \brief Changes the provided line segment's properties based on its 4 neighbors
 template <data::Orientation Orientation,
           data::TransportLineData::LineOrientation BendLeft,
@@ -498,6 +532,7 @@ void UpdateSegmentProps(data::TransportLineData* line_data,
 	case LeftOnly:
 		line_segment->terminationType = game::TransportSegment::TerminationType::left_only;
 
+		// Change segment opposite to current one, which may also point to the same target segment
 #define LEFT_ONLY_CHANGE_TERMINATION_TYPE\
 			TryChangeTerminationType<game::TransportSegment::TerminationType::bend_right,\
 			                         game::TransportSegment::TerminationType::right_only>(
@@ -551,7 +586,7 @@ void UpdateSegmentProps(data::TransportLineData* line_data,
 
 
 	shift_segment:
-		line_segment->length++;
+		ShiftSegmentHead<true>(*line_segment);
 		UpdateSegmentTiles(world_data, world_coords, line_segment, 1);
 		break;
 
@@ -560,43 +595,45 @@ void UpdateSegmentProps(data::TransportLineData* line_data,
 	}
 }
 
-void data::TransportLine::UpdateSegmentHead(game::WorldData& world_data,
-                                            const game::WorldData::WorldPair& world_coords,
-                                            LineData4Way& line_data,
-                                            const std::shared_ptr<game::TransportSegment>& line_segment) {
+///
+/// \brief Change current line segment termination type to a bend depending on neighbor termination orientation
+void UpdateTermination(game::WorldData& world_data,
+                       const game::WorldData::WorldPair& world_coords,
+                       LineData4Way& line_data,
+                       const std::shared_ptr<game::TransportSegment>& line_segment) {
 	switch (line_segment->direction) {
 
-	case Orientation::up:
-		UpdateSegmentProps<Orientation::up,
-		                   TransportLineData::LineOrientation::up_left,
-		                   TransportLineData::LineOrientation::up_right,
-		                   TransportLineData::LineOrientation::right,
-		                   TransportLineData::LineOrientation::left>(line_data[0],
-		                                                             world_data, world_coords, line_segment);
+	case data::Orientation::up:
+		UpdateSegmentProps<data::Orientation::up,
+		                   data::TransportLineData::LineOrientation::up_left,
+		                   data::TransportLineData::LineOrientation::up_right,
+		                   data::TransportLineData::LineOrientation::right,
+		                   data::TransportLineData::LineOrientation::left>(line_data[0],
+		                                                                   world_data, world_coords, line_segment);
 		break;
-	case Orientation::right:
-		UpdateSegmentProps<Orientation::right,
-		                   TransportLineData::LineOrientation::right_up,
-		                   TransportLineData::LineOrientation::right_down,
-		                   TransportLineData::LineOrientation::down,
-		                   TransportLineData::LineOrientation::up>(line_data[1],
-		                                                           world_data, world_coords, line_segment);
+	case data::Orientation::right:
+		UpdateSegmentProps<data::Orientation::right,
+		                   data::TransportLineData::LineOrientation::right_up,
+		                   data::TransportLineData::LineOrientation::right_down,
+		                   data::TransportLineData::LineOrientation::down,
+		                   data::TransportLineData::LineOrientation::up>(line_data[1],
+		                                                                 world_data, world_coords, line_segment);
 		break;
-	case Orientation::down:
-		UpdateSegmentProps<Orientation::down,
-		                   TransportLineData::LineOrientation::down_right,
-		                   TransportLineData::LineOrientation::down_left,
-		                   TransportLineData::LineOrientation::left,
-		                   TransportLineData::LineOrientation::right>(line_data[2],
-		                                                              world_data, world_coords, line_segment);
+	case data::Orientation::down:
+		UpdateSegmentProps<data::Orientation::down,
+		                   data::TransportLineData::LineOrientation::down_right,
+		                   data::TransportLineData::LineOrientation::down_left,
+		                   data::TransportLineData::LineOrientation::left,
+		                   data::TransportLineData::LineOrientation::right>(line_data[2],
+		                                                                    world_data, world_coords, line_segment);
 		break;
-	case Orientation::left:
-		UpdateSegmentProps<Orientation::left,
-		                   TransportLineData::LineOrientation::left_down,
-		                   TransportLineData::LineOrientation::left_up,
-		                   TransportLineData::LineOrientation::up,
-		                   TransportLineData::LineOrientation::down>(line_data[3],
-		                                                             world_data, world_coords, line_segment);
+	case data::Orientation::left:
+		UpdateSegmentProps<data::Orientation::left,
+		                   data::TransportLineData::LineOrientation::left_down,
+		                   data::TransportLineData::LineOrientation::left_up,
+		                   data::TransportLineData::LineOrientation::up,
+		                   data::TransportLineData::LineOrientation::down>(line_data[3],
+		                                                                   world_data, world_coords, line_segment);
 		break;
 
 	default:
@@ -604,14 +641,32 @@ void data::TransportLine::UpdateSegmentHead(game::WorldData& world_data,
 	}
 }
 
-data::TransportLineData* data::TransportLine::InitTransportSegment(game::WorldData& world_data,
-                                                                   const game::WorldData::WorldPair&
-                                                                   world_coords,
-                                                                   const Orientation orientation,
-                                                                   game::ChunkTileLayer& tile_layer,
-                                                                   LineData4Way& line_data) const {
+///
+/// \brief Initializes line data and groups transport segments
+/// Sets the transport segment grouped / newly created with in tile_layer and returns it
+/// \return Created data for at tile_layer, was a new transport segment created
+data::TransportLineData& InitTransportSegment(game::WorldData& world_data,
+                                              const game::WorldData::WorldPair& world_coords,
+                                              const data::Orientation orientation,
+                                              game::ChunkTileLayer& tile_layer,
+                                              LineData4Way& line_data) {
+	/*
+	 * Transport line grouping rules:
+	 *
+	 * < < < [1, 2, 3] - Direction [order];
+	 * Line ahead:
+	 *		- Extends length of transport line segment
+	 *
+	 * < < < [3, 2, 1]
+	 * Line behind:
+	 *		- Moves head of transport segment, shift leading item 1 tile back
+	 *		
+	 * < < < [1, 3, 2]
+	 * Line ahead and behind:
+	 *		- Behaves as line ahead
+	 */
 
-	static_assert(static_cast<int>(Orientation::left) == 3);  // Indexing line_data will be out of range 
+	static_assert(static_cast<int>(data::Orientation::left) == 3);  // Indexing line_data will be out of range 
 
 	auto& origin_chunk = *world_data.GetChunk(world_coords);
 
@@ -625,7 +680,7 @@ data::TransportLineData* data::TransportLine::InitTransportSegment(game::WorldDa
 		group_behind // Segment behind current location
 	} status;
 	const auto index  = static_cast<int>(orientation);
-	const int i_index = InvertOrientation(index);
+	const int i_index = data::InvertOrientation(index);
 
 	if (!line_data[index] ||
 		line_data[index]->lineSegment->direction != orientation) {
@@ -680,14 +735,13 @@ data::TransportLineData* data::TransportLine::InitTransportSegment(game::WorldDa
 		// The transport segment's position is adjusted by init_transport_segment
 		// Move the segment head behind forwards to current position
 		line_segment = line_data[i_index]->lineSegment;
-		line_segment->length++;
-		line_segment->itemOffset++;
+		ShiftSegmentHead<true>(*line_segment);
 		break;
 
 	case InitSegmentStatus::group_ahead:
 		line_segment = line_data[index]->lineSegment;
 
-		line_data[index]->lineSegment->length++;
+		line_data[index]->lineSegment->length++;  // Lengthening its tail, not head
 		line_segment_index = line_data[index]->lineSegmentIndex + 1;
 		break;
 
@@ -697,7 +751,7 @@ data::TransportLineData* data::TransportLine::InitTransportSegment(game::WorldDa
 	}
 
 	// Create unique data at tile
-	auto* unique_data             = tile_layer.MakeUniqueData<TransportLineData>(line_segment);
+	auto* unique_data             = tile_layer.MakeUniqueData<data::TransportLineData>(line_segment);
 	unique_data->lineSegmentIndex = line_segment_index;
 
 	// Line data is not initialized yet inside switch
@@ -712,7 +766,7 @@ data::TransportLineData* data::TransportLine::InitTransportSegment(game::WorldDa
 		UpdateSegmentTiles(world_data, world_coords, line_segment);
 	}
 
-	return unique_data;
+	return *unique_data;
 }
 
 void data::TransportLine::OnBuild(game::WorldData& world_data,
@@ -727,7 +781,7 @@ void data::TransportLine::OnBuild(game::WorldData& world_data,
 
 	// ======================================================================
 	// Create data
-	TransportLineData& line_data = *InitTransportSegment(world_data, world_coords, orientation, tile_layer, line_data_4);
+	TransportLineData& line_data = InitTransportSegment(world_data, world_coords, orientation, tile_layer, line_data_4);
 	const std::shared_ptr<game::TransportSegment>& line_segment = line_data.lineSegment;
 
 	const TransportLineData::LineOrientation line_orientation = GetLineOrientation(orientation, up, right, down, left);
@@ -741,18 +795,17 @@ void data::TransportLine::OnBuild(game::WorldData& world_data,
 	// This has to be done PRIOR to adjusting for bends
 
 	// Take the 4 transport lines neighboring the center as parameters to avoid recalculating them
-	UpdateNeighboringOrientation(
+	UpdateNeighborOrientation(
 		world_data, world_coords,
-		up, right, down, left,
+		line_data_4,
 		static_cast<TransportLineData*>(tile_layer.GetUniqueData()));
 
-	// Change current line segment termination type to a bend depending on neighbor termination orientation
-	UpdateSegmentHead(world_data, world_coords, line_data_4, line_segment);
+	UpdateTermination(world_data, world_coords, line_data_4, line_segment);
 
 	// Updates the termination type and length of neighboring lines
-	UpdateNeighborLines<false>(world_data,
-	                          world_coords.first, world_coords.second,
-	                          line_orientation);
+	UpdateNeighborTermination<false>(world_data,
+	                                 world_coords.first, world_coords.second,
+	                                 line_orientation);
 
 	// ======================================================================
 	// Set the target_segment to the neighbor it is pointing to, or the neighbor's target segment which is pointing to this
@@ -814,9 +867,9 @@ void data::TransportLine::OnNeighborUpdate(game::WorldData& world_data,
 	line_data->lineSegment->left.index  = 0;
 	line_data->lineSegment->right.index = 0;
 
-	UpdateNeighborLines<true>(world_data,
-	                           receive_world_coords.first, receive_world_coords.second,
-	                           line_data->orientation);
+	UpdateNeighborTermination<true>(world_data,
+	                                receive_world_coords.first, receive_world_coords.second,
+	                                line_data->orientation);
 }
 
 //
@@ -838,10 +891,15 @@ void data::TransportLine::OnNeighborUpdate(game::WorldData& world_data,
 // ======================================================================
 // Remove
 
-void data::TransportLine::DisconnectTargetSegment(game::WorldData& world_data,
-                                                  const game::WorldData::WorldPair& world_coords,
-                                                  TransportLineData* target,
-                                                  TransportLineData* line_data) {
+///
+/// \brief Updates neighboring segments after transport line is removed 
+/// \param world_coords Coords of transport line removed
+/// \param line_data Neighboring line segment
+/// \param target Removed line segment
+void DisconnectTargetSegment(game::WorldData& world_data,
+                             const game::WorldData::WorldPair& world_coords,
+                             data::TransportLineData* target,
+                             data::TransportLineData* line_data) {
 
 	if (line_data &&
 		line_data->lineSegment->targetSegment == target->lineSegment.get()) {
@@ -857,8 +915,7 @@ void data::TransportLine::DisconnectTargetSegment(game::WorldData& world_data,
 		case game::TransportSegment::TerminationType::bend_right:
 		case game::TransportSegment::TerminationType::right_only:
 		case game::TransportSegment::TerminationType::left_only:
-			line_segment->itemOffset--;
-			line_segment->length--;
+			ShiftSegmentHead<false>(*line_segment);
 			line_segment->terminationType = game::TransportSegment::TerminationType::straight;
 
 			// Move the neighboring line segments back if they are not straight
@@ -883,29 +940,29 @@ double ToChunkOffset(const game::WorldData::WorldCoord world_coord) {
 void data::TransportLine::OnRemove(game::WorldData& world_data,
                                    const game::WorldData::WorldPair& world_coords,
                                    game::ChunkTileLayer& tile_layer) const {
-	auto* t_center = GetLineData(world_data, world_coords.first, world_coords.second - 1);
-	auto* c_left   = GetLineData(world_data, world_coords.first - 1, world_coords.second);
-	auto* c_right  = GetLineData(world_data, world_coords.first + 1, world_coords.second);
-	auto* b_center = GetLineData(world_data, world_coords.first, world_coords.second + 1);
+	auto* up    = GetLineData(world_data, world_coords.first, world_coords.second - 1);
+	auto* right = GetLineData(world_data, world_coords.first + 1, world_coords.second);
+	auto* down  = GetLineData(world_data, world_coords.first, world_coords.second + 1);
+	auto* left  = GetLineData(world_data, world_coords.first - 1, world_coords.second);
+	TransportLineData* line_data_4[4]{up, right, down, left};
 
-	UpdateNeighboringOrientation(world_data, world_coords,
-	                             t_center, c_right, b_center, c_left, nullptr);
+	UpdateNeighborOrientation(world_data, world_coords, line_data_4, nullptr);
 
 	auto* line_data = static_cast<TransportLineData*>(tile_layer.GetUniqueData());
 
 	// Set neighboring transport line segments which points to this segment's target_segment to nullptr
-	DisconnectTargetSegment(world_data, world_coords, line_data, t_center);
-	DisconnectTargetSegment(world_data, world_coords, line_data, c_left);
-	DisconnectTargetSegment(world_data, world_coords, line_data, c_right);
-	DisconnectTargetSegment(world_data, world_coords, line_data, b_center);
+	DisconnectTargetSegment(world_data, world_coords, line_data, up);
+	DisconnectTargetSegment(world_data, world_coords, line_data, right);
+	DisconnectTargetSegment(world_data, world_coords, line_data, down);
+	DisconnectTargetSegment(world_data, world_coords, line_data, left);
 
-	game::Chunk& chunk = *world_data.GetChunk(world_coords);
+	auto& chunk = *world_data.GetChunk(world_coords);
 
 	// o_ = old
 	// n_ = new
 
-	auto& o_line_data                                             = *static_cast<TransportLineData*>(tile_layer.GetUniqueData());
-	const std::shared_ptr<game::TransportSegment>& o_line_segment = o_line_data.lineSegment;
+	auto& o_line_data          = *static_cast<TransportLineData*>(tile_layer.GetUniqueData());
+	const auto& o_line_segment = o_line_data.lineSegment;
 
 	auto n_seg_coords = world_coords;
 

--- a/src/game/logic/transport_line_controller.cpp
+++ b/src/game/logic/transport_line_controller.cpp
@@ -166,7 +166,7 @@ void UpdateSide(const game::TransportLineOffset& tiles_moved, game::TransportSeg
 					// |   |   |   |
 					// 3   2   1   0
 					// targetOffset of 0: Length is 1
-					length = 1 + segment.targetInsertOffset;
+					length = static_cast<double>(1) + segment.targetInsertOffset;
 					break;
 
 				default:

--- a/src/game/logic/transport_line_controller.cpp
+++ b/src/game/logic/transport_line_controller.cpp
@@ -10,43 +10,45 @@
 #include "game/logic/transport_segment.h"
 #include "game/world/world_data.h"
 
-void ApplyTerminationDeductionL(const jactorio::game::TransportSegment::TerminationType termination_type,
-                                jactorio::game::TransportLineOffset& offset) {
+using namespace jactorio;
+
+void ApplyTerminationDeductionL(const game::TransportSegment::TerminationType termination_type,
+                                game::TransportLineOffset& offset) {
 	switch (termination_type) {
 		// Feeding into another belt also needs to be deducted to feed at the right offset on the target belt
-	case jactorio::game::TransportSegment::TerminationType::left_only:
-	case jactorio::game::TransportSegment::TerminationType::bend_left:
-		offset -= dec::decimal_cast<jactorio::game::kTransportLineDecimalPlace>(
-			jactorio::game::TransportSegment::kBendLeftLReduction);
+	case game::TransportSegment::TerminationType::left_only:
+	case game::TransportSegment::TerminationType::bend_left:
+		offset -= dec::decimal_cast<game::kTransportLineDecimalPlace>(
+			game::TransportSegment::kBendLeftLReduction);
 		break;
 
-	case jactorio::game::TransportSegment::TerminationType::right_only:
-	case jactorio::game::TransportSegment::TerminationType::bend_right:
-		offset -= dec::decimal_cast<jactorio::game::kTransportLineDecimalPlace>(
-			jactorio::game::TransportSegment::kBendRightLReduction);
+	case game::TransportSegment::TerminationType::right_only:
+	case game::TransportSegment::TerminationType::bend_right:
+		offset -= dec::decimal_cast<game::kTransportLineDecimalPlace>(
+			game::TransportSegment::kBendRightLReduction);
 		break;
 
-	case jactorio::game::TransportSegment::TerminationType::straight:
+	case game::TransportSegment::TerminationType::straight:
 		break;
 	}
 }
 
-void ApplyTerminationDeductionR(const jactorio::game::TransportSegment::TerminationType termination_type,
-                                jactorio::game::TransportLineOffset& offset) {
+void ApplyTerminationDeductionR(const game::TransportSegment::TerminationType termination_type,
+                                game::TransportLineOffset& offset) {
 	switch (termination_type) {
-	case jactorio::game::TransportSegment::TerminationType::left_only:
-	case jactorio::game::TransportSegment::TerminationType::bend_left:
-		offset -= dec::decimal_cast<jactorio::game::kTransportLineDecimalPlace>(
-			jactorio::game::TransportSegment::kBendLeftRReduction);
+	case game::TransportSegment::TerminationType::left_only:
+	case game::TransportSegment::TerminationType::bend_left:
+		offset -= dec::decimal_cast<game::kTransportLineDecimalPlace>(
+			game::TransportSegment::kBendLeftRReduction);
 		break;
 
-	case jactorio::game::TransportSegment::TerminationType::right_only:
-	case jactorio::game::TransportSegment::TerminationType::bend_right:
-		offset -= dec::decimal_cast<jactorio::game::kTransportLineDecimalPlace>(
-			jactorio::game::TransportSegment::kBendRightRReduction);
+	case game::TransportSegment::TerminationType::right_only:
+	case game::TransportSegment::TerminationType::bend_right:
+		offset -= dec::decimal_cast<game::kTransportLineDecimalPlace>(
+			game::TransportSegment::kBendRightRReduction);
 		break;
 
-	case jactorio::game::TransportSegment::TerminationType::straight:
+	case game::TransportSegment::TerminationType::straight:
 		break;
 	}
 }
@@ -55,13 +57,13 @@ void ApplyTerminationDeductionR(const jactorio::game::TransportSegment::Terminat
 /// \brief Sets index to the next item with a distance greater than item_width and decrement it
 /// If there is no item AND has_target_segment == false, index is set as size of transport line
 /// \return true if an item was decremented
-J_NODISCARD bool MoveNextItem(const jactorio::game::TransportLineOffset& tiles_moved,
-                              std::deque<jactorio::game::TransportLineItem>& line_side,
+J_NODISCARD bool MoveNextItem(const game::TransportLineOffset& tiles_moved,
+                              std::deque<game::TransportLineItem>& line_side,
                               uint16_t& index, const bool has_target_segment) {
 	for (decltype(line_side.size()) i = index + 1; i < line_side.size(); ++i) {
 		auto& i_item_offset = line_side[i].first;
-		if (i_item_offset > dec::decimal_cast<jactorio::game::kTransportLineDecimalPlace>(
-			jactorio::game::kItemSpacing)) {
+		if (i_item_offset > dec::decimal_cast<game::kTransportLineDecimalPlace>(
+			game::kItemSpacing)) {
 
 			// Found a valid item to decrement
 			index = i;
@@ -72,7 +74,7 @@ J_NODISCARD bool MoveNextItem(const jactorio::game::TransportLineOffset& tiles_m
 
 	// Failed to find another item
 	index = 0;
-	
+
 	/*
 	// set to 1 past the index of the last item (stop the transport line permanently) if there is no target segment
 	if (!has_target_segment)
@@ -85,7 +87,7 @@ J_NODISCARD bool MoveNextItem(const jactorio::game::TransportLineOffset& tiles_m
 }
 
 template <bool IsLeft>
-void UpdateSide(const jactorio::game::TransportLineOffset& tiles_moved, jactorio::game::TransportSegment& segment) {
+void UpdateSide(const game::TransportLineOffset& tiles_moved, game::TransportSegment& segment) {
 	using namespace jactorio;
 	auto& side      = segment.GetSide(IsLeft);
 	uint16_t& index = side.index;
@@ -113,7 +115,7 @@ void UpdateSide(const jactorio::game::TransportLineOffset& tiles_moved, jactorio
 					// |   |   |   |
 					// 3   2   1   0
 					// targetOffset of 0: Length is 1
-					length = segment.targetInsertOffset + 1.f;
+					length = 1 + segment.targetInsertOffset;
 					break;
 
 				default:
@@ -128,11 +130,22 @@ void UpdateSide(const jactorio::game::TransportLineOffset& tiles_moved, jactorio
 			// Account for the termination type of the line segments for the offset from start to insert into
 			if constexpr (IsLeft) {
 				ApplyTerminationDeductionL(segment.terminationType, target_offset);
-				ApplyTerminationDeductionL(target_segment.terminationType, target_offset);
+
+				// Transition into right lane
+				if (segment.terminationType == game::TransportSegment::TerminationType::right_only)
+					ApplyTerminationDeductionR(target_segment.terminationType, target_offset);
+				else 
+					ApplyTerminationDeductionL(target_segment.terminationType, target_offset);
 			}
 			else {
 				ApplyTerminationDeductionR(segment.terminationType, target_offset);
-				ApplyTerminationDeductionR(target_segment.terminationType, target_offset);
+
+
+				// Transition into left lane
+				if (segment.terminationType == game::TransportSegment::TerminationType::left_only)
+					ApplyTerminationDeductionL(target_segment.terminationType, target_offset);
+				else 
+					ApplyTerminationDeductionR(target_segment.terminationType, target_offset);
 			}
 
 			bool moved_item;
@@ -223,8 +236,7 @@ void UpdateSide(const jactorio::game::TransportLineOffset& tiles_moved, jactorio
 ///
 /// \brief Moves items for transport lines
 /// \param l_chunk Chunk to update
-void LogicUpdateMoveItems(const jactorio::game::Chunk& l_chunk) {
-	using namespace jactorio;
+void LogicUpdateMoveItems(const game::Chunk& l_chunk) {
 	const auto& layers = l_chunk.GetLogicGroup(game::Chunk::LogicGroup::transport_line);
 
 	// Each object layer holds a transport line segment
@@ -259,8 +271,7 @@ void LogicUpdateMoveItems(const jactorio::game::Chunk& l_chunk) {
 ///
 /// \brief Transitions items on transport lines to other lines and modifies whether of not the line is active
 /// \param l_chunk Chunk to update
-void LogicUpdateTransitionItems(const jactorio::game::Chunk& l_chunk) {
-	using namespace jactorio;
+void LogicUpdateTransitionItems(const game::Chunk& l_chunk) {
 	const auto& layers = l_chunk.GetLogicGroup(game::Chunk::LogicGroup::transport_line);
 
 	// Each object layer holds a transport line segment
@@ -278,7 +289,7 @@ void LogicUpdateTransitionItems(const jactorio::game::Chunk& l_chunk) {
 	}
 }
 
-void jactorio::game::TransportLineLogicUpdate(WorldData& world_data) {
+void game::TransportLineLogicUpdate(WorldData& world_data) {
 	// The logic update of transport line items occur in 2 stages:
 	// 		1. Move items on their transport lines
 	//		2. Check if any items have reached the end of their lines, and need to be moved to another one

--- a/src/game/logic/transport_line_controller.cpp
+++ b/src/game/logic/transport_line_controller.cpp
@@ -113,12 +113,12 @@ J_NODISCARD bool MoveNextItem(const game::TransportLineOffset& tiles_moved,
                               uint16_t& index, const bool has_target_segment) {
 	for (size_t i = static_cast<size_t>(index) + 1; i < line_side.size(); ++i) {
 		auto& i_item_offset = line_side[i].first;
-		if (i_item_offset > dec::decimal_cast<game::kTransportLineDecimalPlace>(
-			game::kItemSpacing)) {
-
+		if (i_item_offset > dec::decimal_cast<game::kTransportLineDecimalPlace>(game::kItemSpacing)) {
 			// Found a valid item to decrement
-			index = i;
+			if (!has_target_segment)
+				index = i;  // Always check every item from index 0 if there is a target segment as the previous item may have moved
 			i_item_offset -= tiles_moved;
+
 			return true;
 		}
 	}

--- a/src/game/logic/transport_segment.cpp
+++ b/src/game/logic/transport_segment.cpp
@@ -11,7 +11,7 @@ bool jactorio::game::TransportLane::IsActive() const {
 	return !(lane.empty() || index >= lane.size());
 }
 
-bool jactorio::game::TransportLane::CanInsert(TransportLineOffset start_offset, const ItemOffsetT item_offset) {
+bool jactorio::game::TransportLane::CanInsert(TransportLineOffset start_offset, const IntOffsetT item_offset) {
 	start_offset += TransportLineOffset(item_offset);
 	assert(start_offset.getAsDouble() >= 0);
 
@@ -47,7 +47,7 @@ bool jactorio::game::TransportLane::CanInsert(TransportLineOffset start_offset, 
 	return offset <= start_offset;
 }
 
-void jactorio::game::TransportLane::AppendItem(BeginOffsetT offset, const data::Item* item) {
+void jactorio::game::TransportLane::AppendItem(FloatOffsetT offset, const data::Item* item) {
 	// A minimum distance of item_spacing is maintained between items (AFTER the initial item)
 	if (offset < kItemSpacing && !lane.empty())
 		offset = kItemSpacing;
@@ -56,7 +56,7 @@ void jactorio::game::TransportLane::AppendItem(BeginOffsetT offset, const data::
 	backItemDistance += TransportLineOffset{offset};
 }
 
-void jactorio::game::TransportLane::InsertItem(BeginOffsetT offset, const data::Item* item, const ItemOffsetT item_offset) {
+void jactorio::game::TransportLane::InsertItem(FloatOffsetT offset, const data::Item* item, const IntOffsetT item_offset) {
 	offset += item_offset;
 	assert(offset >= 0);
 
@@ -94,8 +94,8 @@ loop_exit:
 	lane.emplace(it, target_offset, item);
 }
 
-bool jactorio::game::TransportLane::TryInsertItem(const BeginOffsetT offset, const data::Item* item,
-                                                  const ItemOffsetT item_offset) {
+bool jactorio::game::TransportLane::TryInsertItem(const FloatOffsetT offset, const data::Item* item,
+                                                  const IntOffsetT item_offset) {
 	if (!CanInsert(dec::decimal_cast<kTransportLineDecimalPlace>(offset), item_offset))
 		return false;
 
@@ -107,7 +107,7 @@ bool jactorio::game::TransportLane::TryInsertItem(const BeginOffsetT offset, con
 	return true;
 }
 
-const jactorio::data::Item* jactorio::game::TransportLane::TryPopItem(const BeginOffsetT offset, const BeginOffsetT epsilon) {
+const jactorio::data::Item* jactorio::game::TransportLane::TryPopItem(const FloatOffsetT offset, const FloatOffsetT epsilon) {
 
 	const TransportLineOffset target_offset{offset - epsilon};
 	TransportLineOffset offset_counter{0};
@@ -150,15 +150,15 @@ bool jactorio::game::TransportSegment::IsActive(const bool left_side) const {
 	return left_side ? left.IsActive() : right.IsActive();
 }
 
-void jactorio::game::TransportSegment::AppendItem(const bool left_side, const BeginOffsetT offset, const data::Item* item) {
+void jactorio::game::TransportSegment::AppendItem(const bool left_side, const FloatOffsetT offset, const data::Item* item) {
 	left_side ? left.AppendItem(offset, item) : right.AppendItem(offset, item);
 }
 
-void jactorio::game::TransportSegment::InsertItem(const bool left_side, const BeginOffsetT offset, const data::Item* item) {
+void jactorio::game::TransportSegment::InsertItem(const bool left_side, const FloatOffsetT offset, const data::Item* item) {
 	left_side ? left.InsertItem(offset, item, 0) : right.InsertItem(offset, item, 0);
 }
 
-bool jactorio::game::TransportSegment::TryInsertItem(const bool left_side, const BeginOffsetT offset, const data::Item* item) {
+bool jactorio::game::TransportSegment::TryInsertItem(const bool left_side, const FloatOffsetT offset, const data::Item* item) {
 	return left_side ? left.TryInsertItem(offset, item, 0) : right.TryInsertItem(offset, item, 0);
 }
 
@@ -168,20 +168,24 @@ bool jactorio::game::TransportSegment::CanInsertAbs(const bool left_side, const 
 	return left_side ? left.CanInsert(start_offset, itemOffset) : right.CanInsert(start_offset, itemOffset);
 }
 
-void jactorio::game::TransportSegment::InsertItemAbs(const bool left_side, const BeginOffsetT offset, const data::Item* item) {
+void jactorio::game::TransportSegment::InsertItemAbs(const bool left_side, const FloatOffsetT offset, const data::Item* item) {
 	left_side ? left.InsertItem(offset, item, itemOffset) : right.InsertItem(offset, item, itemOffset);
 }
 
-bool jactorio::game::TransportSegment::TryInsertItemAbs(const bool left_side, const BeginOffsetT offset,
+bool jactorio::game::TransportSegment::TryInsertItemAbs(const bool left_side, const FloatOffsetT offset,
                                                         const data::Item* item) {
 	return left_side ? left.TryInsertItem(offset, item, itemOffset) : right.TryInsertItem(offset, item, itemOffset);
 }
 
 const jactorio::data::Item* jactorio::game::TransportSegment::TryPopItemAbs(const bool left_side,
-                                                                            const BeginOffsetT offset, const BeginOffsetT epsilon) {
+                                                                            const FloatOffsetT offset, const FloatOffsetT epsilon) {
 	return left_side ? left.TryPopItem(offset, epsilon) : right.TryPopItem(offset, epsilon);
 }
 
-void jactorio::game::TransportSegment::GetOffsetAbs(BeginOffsetT& val) const {
+void jactorio::game::TransportSegment::GetOffsetAbs(IntOffsetT& val) const {
+	val -= itemOffset;
+}
+
+void jactorio::game::TransportSegment::GetOffsetAbs(FloatOffsetT& val) const {
 	val -= itemOffset;
 }

--- a/src/renderer/gui/gui_menus_debug.cpp
+++ b/src/renderer/gui/gui_menus_debug.cpp
@@ -340,7 +340,7 @@ void jactorio::renderer::DebugTransportLineInfo(game::PlayerData& player_data) {
 		}
 
 		ImGui::Text("Item offset %d", segment.itemOffset);
-		ImGui::Text("Target insertion offset %f", segment.targetInsertOffset);
+		ImGui::Text("Target insertion offset %d", segment.targetInsertOffset);
 		ImGui::Text("Length, Index: %d %d", segment.length, data->lineSegmentIndex);
 
 		{

--- a/src/renderer/rendering/data_renderer.cpp
+++ b/src/renderer/rendering/data_renderer.cpp
@@ -230,7 +230,7 @@ prepare_right:
 	case game::TransportSegment::TerminationType::bend_left:
 		switch (line_segment.direction) {
 		case data::Orientation::up:
-			tile_y_offset += game::kLineUpBrRItemOffsetY;
+			tile_y_offset += game::kLineUpBlRItemOffsetY;
 			break;
 		case data::Orientation::right:
 			tile_x_offset += game::kLineRightBlRItemOffsetX;

--- a/test/data/prototype/entity/transport/transport_lineTests.cpp
+++ b/test/data/prototype/entity/transport/transport_lineTests.cpp
@@ -716,6 +716,10 @@ namespace jactorio::data
 
 		EXPECT_EQ(GetLineData({0, 1}).lineSegment->targetInsertOffset, 1);
 		EXPECT_EQ(GetLineData({2, 1}).lineSegment->targetInsertOffset, 1);
+
+		// Incremented 1 forwards	
+		EXPECT_EQ(GetLineData({0, 1}).lineSegment->itemOffset, 1);
+		EXPECT_EQ(GetLineData({2, 1}).lineSegment->itemOffset, 1);
 	}
 
 	TEST_F(TransportLineTest, OnBuildRightChangeBendToSideOnly) {
@@ -865,10 +869,12 @@ namespace jactorio::data
 		{
 			auto& line_segment = GetSegment(tile_layers[0]);
 			EXPECT_EQ(line_segment.terminationType, jactorio::game::TransportSegment::TerminationType::right_only);
+			EXPECT_EQ(line_segment.itemOffset, 1);  // Incremented 1 when turned side only
 		}
 		{
 			auto& line_segment = GetSegment(tile_layers[1]);
 			EXPECT_EQ(line_segment.terminationType, jactorio::game::TransportSegment::TerminationType::left_only);
+			EXPECT_EQ(line_segment.itemOffset, 1);
 		}
 
 		EXPECT_EQ(GetLineSegmentIndex({0, 0}), 1);

--- a/test/data/prototype/entity/transport/transport_lineTests.cpp
+++ b/test/data/prototype/entity/transport/transport_lineTests.cpp
@@ -158,19 +158,22 @@ namespace jactorio::data
 
 		// Bend
 
-		void ValidateBendToSideOnly() {
+		///
+		/// \param l_index index for left only segment in logic group
+		/// \param r_index index for right only segment in logic group
+		void ValidateBendToSideOnly(const size_t l_index = 2, const size_t r_index = 1) {
 			game::Chunk& chunk = *worldData_.GetChunkC(0, 0);
-			auto& tile_layers  = chunk.GetLogicGroup(game::Chunk::LogicGroup::transport_line);
+			auto& logic_group  = chunk.GetLogicGroup(game::Chunk::LogicGroup::transport_line);
 
-			ASSERT_EQ(tile_layers.size(), 3);
+			ASSERT_EQ(logic_group.size(), 3);
 
 			{
-				auto& line_segment = GetSegment(tile_layers[1]);
+				auto& line_segment = GetSegment(logic_group[r_index]);
 				EXPECT_EQ(line_segment.terminationType, jactorio::game::TransportSegment::TerminationType::right_only);
 				EXPECT_EQ(line_segment.length, 2);
 			}
 			{
-				auto& line_segment = GetSegment(tile_layers[2]);
+				auto& line_segment = GetSegment(logic_group[l_index]);
 				EXPECT_EQ(line_segment.terminationType, jactorio::game::TransportSegment::TerminationType::left_only);
 				EXPECT_EQ(line_segment.length, 2);
 			}
@@ -729,15 +732,19 @@ namespace jactorio::data
 		 *   > > 
 		 *   ^
 		 */
-		BuildTransportLine({1, 1}, Orientation::right);
-		BuildTransportLine({2, 1}, Orientation::right);
-
 		BuildTransportLine({1, 2}, Orientation::up);
 		BuildTransportLine({1, 0}, Orientation::down);
 
-		ValidateBendToSideOnly();
+		BuildTransportLine({1, 1}, Orientation::right);
+		BuildTransportLine({2, 1}, Orientation::right);
+
+
+		ValidateBendToSideOnly(1, 0);
 		EXPECT_EQ(GetLineData({1, 0}).lineSegment->targetInsertOffset, 0);
 		EXPECT_EQ(GetLineData({1, 2}).lineSegment->targetInsertOffset, 0);
+
+		EXPECT_EQ(GetLineData({1, 0}).lineSegment->itemOffset, 1);
+		EXPECT_EQ(GetLineData({1, 2}).lineSegment->itemOffset, 1);
 	}
 
 	TEST_F(TransportLineTest, OnBuildDownChangeBendToSideOnly) {

--- a/test/data/prototype/entity/transport/transport_lineTests.cpp
+++ b/test/data/prototype/entity/transport/transport_lineTests.cpp
@@ -41,8 +41,8 @@ namespace jactorio::data
 		///
 		/// \brief Sets the prototype pointer for a transport line at tile
 		void BuildTransportLine(
-			const Orientation orientation,
-			const std::pair<uint32_t, uint32_t> world_coords) {
+			const std::pair<uint32_t, uint32_t> world_coords,
+			const Orientation orientation) {
 
 			auto& layer = worldData_.GetTile(world_coords.first, world_coords.second)
 			                        ->GetLayer(game::ChunkTile::ChunkLayer::entity);
@@ -704,11 +704,11 @@ namespace jactorio::data
 		 *   ^
 		 * > ^ < 
 		 */
-		BuildTransportLine(Orientation::up, {1, 0});
-		BuildTransportLine(Orientation::up, {1, 1});
+		BuildTransportLine({1, 0}, Orientation::up);
+		BuildTransportLine({1, 1}, Orientation::up);
 
-		BuildTransportLine(Orientation::left, {2, 1});
-		BuildTransportLine(Orientation::right, {0, 1});
+		BuildTransportLine({2, 1}, Orientation::left);
+		BuildTransportLine({0, 1}, Orientation::right);
 
 		ValidateBendToSideOnly();
 		EXPECT_EQ(GetLineSegmentIndex({0, 1}), 1);
@@ -725,11 +725,11 @@ namespace jactorio::data
 		 *   > > 
 		 *   ^
 		 */
-		BuildTransportLine(Orientation::right, {1, 1});
-		BuildTransportLine(Orientation::right, {2, 1});
+		BuildTransportLine({1, 1}, Orientation::right);
+		BuildTransportLine({2, 1}, Orientation::right);
 
-		BuildTransportLine(Orientation::up, {1, 2});
-		BuildTransportLine(Orientation::down, {1, 0});
+		BuildTransportLine({1, 2}, Orientation::up);
+		BuildTransportLine({1, 0}, Orientation::down);
 
 		ValidateBendToSideOnly();
 		EXPECT_EQ(GetLineData({1, 0}).lineSegment->targetInsertOffset, 0);
@@ -742,11 +742,11 @@ namespace jactorio::data
 		 * > v < 
 		 *   v 
 		 */
-		BuildTransportLine(Orientation::down, {1, 1});
-		BuildTransportLine(Orientation::down, {1, 2});
+		BuildTransportLine({1, 1}, Orientation::down);
+		BuildTransportLine({1, 2}, Orientation::down);
 
-		BuildTransportLine(Orientation::right, {0, 1});
-		BuildTransportLine(Orientation::left, {2, 1});
+		BuildTransportLine({0, 1}, Orientation::right);
+		BuildTransportLine({2, 1}, Orientation::left);
 
 		ValidateBendToSideOnly();
 		EXPECT_EQ(GetLineData({0, 1}).lineSegment->targetInsertOffset, 0);
@@ -760,11 +760,11 @@ namespace jactorio::data
 		 * < < 
 		 *   ^
 		 */
-		BuildTransportLine(Orientation::left, {0, 1});
-		BuildTransportLine(Orientation::left, {1, 1});
+		BuildTransportLine({0, 1}, Orientation::left);
+		BuildTransportLine({1, 1}, Orientation::left);
 
-		BuildTransportLine(Orientation::down, {1, 0});
-		BuildTransportLine(Orientation::up, {1, 2});
+		BuildTransportLine({1, 0}, Orientation::down);
+		BuildTransportLine({1, 2}, Orientation::up);
 
 		ValidateBendToSideOnly();
 		EXPECT_EQ(GetLineData({1, 0}).lineSegment->targetInsertOffset, 1);
@@ -783,12 +783,12 @@ namespace jactorio::data
 		 *   4
 		 * 1 5 2
 		 */
-		BuildTransportLine(Orientation::right, {0, 2});
-		BuildTransportLine(Orientation::left, {2, 2});
+		BuildTransportLine({0, 2}, Orientation::right);
+		BuildTransportLine({2, 2}, Orientation::left);
 
-		BuildTransportLine(Orientation::up, {1, 0});
-		BuildTransportLine(Orientation::up, {1, 1});
-		BuildTransportLine(Orientation::up, {1, 2});
+		BuildTransportLine({1, 0}, Orientation::up);
+		BuildTransportLine({1, 1}, Orientation::up);
+		BuildTransportLine({1, 2}, Orientation::up);
 
 		auto& tile_layers = GetTransportLines({0, 0});
 
@@ -822,10 +822,10 @@ namespace jactorio::data
 		 *  3 
 		 *  1
 		 */
-		BuildTransportLine(Orientation::up, {1, 2});
-		BuildTransportLine(Orientation::down, {1, 0});
+		BuildTransportLine({1, 2}, Orientation::up);
+		BuildTransportLine({1, 0}, Orientation::down);
 
-		BuildTransportLine(Orientation::right, {1, 1});
+		BuildTransportLine({1, 1}, Orientation::right);
 
 		auto& tile_layers = GetTransportLines({0, 0});
 
@@ -853,10 +853,10 @@ namespace jactorio::data
 		 *   
 		 * 1 3 2 
 		 */
-		BuildTransportLine(Orientation::right, {0, 0});
-		BuildTransportLine(Orientation::left, {2, 0});
+		BuildTransportLine({0, 0}, Orientation::right);
+		BuildTransportLine({2, 0}, Orientation::left);
 
-		BuildTransportLine(Orientation::down, {1, 0});
+		BuildTransportLine({1, 0}, Orientation::down);
 
 		auto& tile_layers = GetTransportLines({0, 0});
 
@@ -887,10 +887,10 @@ namespace jactorio::data
 		 *   3 
 		 *   2
 		 */
-		BuildTransportLine(Orientation::down, {0, 0});
-		BuildTransportLine(Orientation::up, {0, 2});
+		BuildTransportLine({0, 0}, Orientation::down);
+		BuildTransportLine({0, 2}, Orientation::up);
 
-		BuildTransportLine(Orientation::left, {0, 1});
+		BuildTransportLine({0, 1}, Orientation::left);
 
 		auto& tile_layers = GetTransportLines({0, 0});
 
@@ -915,8 +915,8 @@ namespace jactorio::data
 
 	TEST_F(TransportLineTest, OnRemoveSetNeighborTargetSegment) {
 		// After removing a transport line, anything that points to it as a target_segment needs to be set to NULL
-		BuildTransportLine(Orientation::left, {0, 0});
-		BuildTransportLine(Orientation::up, {0, 1});
+		BuildTransportLine({0, 0}, Orientation::left);
+		BuildTransportLine({0, 1}, Orientation::up);
 
 
 		TlRemoveEvents({0, 0});
@@ -1021,8 +1021,8 @@ namespace jactorio::data
 		 * ^
 		 * ^
 		 */
-		BuildTransportLine(Orientation::up, {0, 0});
-		BuildTransportLine(Orientation::up, {0, 1});
+		BuildTransportLine({0, 0}, Orientation::up);
+		BuildTransportLine({0, 1}, Orientation::up);
 
 		GroupingValidate({0, 0}, {0, 1});
 	}
@@ -1033,8 +1033,8 @@ namespace jactorio::data
 		 * ^
 		 * ^
 		 */
-		BuildTransportLine(Orientation::up, {0, 1});
-		BuildTransportLine(Orientation::up, {0, 0});
+		BuildTransportLine({0, 1}, Orientation::up);
+		BuildTransportLine({0, 0}, Orientation::up);
 
 		GroupBehindValidate({0, 0}, {0, 1});
 	}
@@ -1043,8 +1043,8 @@ namespace jactorio::data
 		// Since grouping ahead requires adjustment of a position within the current logic chunk, crossing chunks requires special logic
 		worldData_.AddChunk(game::Chunk{0, -1});
 
-		BuildTransportLine(Orientation::up, {0, -1});
-		BuildTransportLine(Orientation::up, {0, 0});
+		BuildTransportLine({0, -1}, Orientation::up);
+		BuildTransportLine({0, 0}, Orientation::up);
 
 		auto* segment = TransportLine::GetTransportSegment(worldData_, 0, 0);
 		ASSERT_TRUE(segment);
@@ -1056,8 +1056,8 @@ namespace jactorio::data
 		// Since grouping ahead requires adjustment of a position within the current logic chunk, crossing chunks requires special logic
 		worldData_.AddChunk(game::Chunk{0, -1});
 
-		BuildTransportLine(Orientation::up, {0, 0});
-		BuildTransportLine(Orientation::up, {0, -1});
+		BuildTransportLine({0, 0}, Orientation::up);
+		BuildTransportLine({0, -1}, Orientation::up);
 
 		auto* segment = TransportLine::GetTransportSegment(worldData_, 0, -1);
 		ASSERT_TRUE(segment);
@@ -1069,8 +1069,8 @@ namespace jactorio::data
 		/*
 		 * > >
 		 */
-		BuildTransportLine(Orientation::right, {1, 0});
-		BuildTransportLine(Orientation::right, {0, 0});
+		BuildTransportLine({1, 0}, Orientation::right);
+		BuildTransportLine({0, 0}, Orientation::right);
 
 		GroupingValidate({1, 0}, {0, 0});
 	}
@@ -1079,8 +1079,8 @@ namespace jactorio::data
 		/*
 		 * > >
 		 */
-		BuildTransportLine(Orientation::right, {0, 0});
-		BuildTransportLine(Orientation::right, {1, 0});
+		BuildTransportLine({0, 0}, Orientation::right);
+		BuildTransportLine({1, 0}, Orientation::right);
 
 		GroupBehindValidate({1, 0}, {0, 0});
 	}
@@ -1090,8 +1090,8 @@ namespace jactorio::data
 		 * v
 		 * v
 		 */
-		BuildTransportLine(Orientation::down, {0, 1});
-		BuildTransportLine(Orientation::down, {0, 0});
+		BuildTransportLine({0, 1}, Orientation::down);
+		BuildTransportLine({0, 0}, Orientation::down);
 
 		GroupingValidate({0, 1}, {0, 0});
 	}
@@ -1101,8 +1101,8 @@ namespace jactorio::data
 		 * v
 		 * v
 		 */
-		BuildTransportLine(Orientation::down, {0, 0});
-		BuildTransportLine(Orientation::down, {0, 1});
+		BuildTransportLine({0, 0}, Orientation::down);
+		BuildTransportLine({0, 1}, Orientation::down);
 
 		GroupBehindValidate({0, 1}, {0, 0});
 	}
@@ -1111,8 +1111,8 @@ namespace jactorio::data
 		/*
 		 * < <
 		 */
-		BuildTransportLine(Orientation::left, {0, 0});
-		BuildTransportLine(Orientation::left, {1, 0});
+		BuildTransportLine({0, 0}, Orientation::left);
+		BuildTransportLine({1, 0}, Orientation::left);
 
 		GroupingValidate({0, 0}, {1, 0});
 	}
@@ -1121,8 +1121,8 @@ namespace jactorio::data
 		/*
 		 * < <
 		 */
-		BuildTransportLine(Orientation::left, {1, 0});
-		BuildTransportLine(Orientation::left, {0, 0});
+		BuildTransportLine({1, 0}, Orientation::left);
+		BuildTransportLine({0, 0}, Orientation::left);
 
 		GroupBehindValidate({0, 0}, {1, 0});
 	}
@@ -1217,21 +1217,33 @@ namespace jactorio::data
 		          GetSegment(tile_layers[1]).targetSegment);
 	}
 
-	TEST_F(TransportLineTest, OnRemoveGroupUpdateIndex) {
+	TEST_F(TransportLineTest, OnRemoveGroupUpdateProperties) {
 		// The segment index must be updated when a formally bend segment becomes straight
+		// The itemOffset must be subtracted
+
 		/*
 		 * />
 		 * ^ 
 		 */
-		AddTransportLine({0, 0}, TransportLineData::LineOrientation::right);
-		AddTransportLine({0, 1}, TransportLineData::LineOrientation::up);
+		BuildTransportLine({0, 1}, Orientation::up);
+		BuildTransportLine({0, 0}, Orientation::right);
+
+		const auto& struct_layer = GetTransportLines({0, 0});
+
+		ASSERT_EQ(struct_layer.size(), 2);
+
+		EXPECT_EQ(GetLineData({0, 1}).lineSegment->itemOffset, 1);
+
+
+		// Remove
+		
 
 		TlRemoveEvents({0, 0});
 
-		const auto& struct_layer = GetTransportLines({0, 0});
 		ASSERT_EQ(struct_layer.size(), 1);
 
 		EXPECT_EQ(GetLineData({0, 1}).lineSegmentIndex, 0);
+		EXPECT_EQ(GetLineData({0, 1}).lineSegment->itemOffset, 0);
 	}
 
 	TEST_F(TransportLineTest, OnRemoveGroupEnd) {

--- a/test/game/logic/transport_line_controllerTests.cpp
+++ b/test/game/logic/transport_line_controllerTests.cpp
@@ -5,7 +5,6 @@
 
 #include <memory>
 
-
 #include "jactorioTests.h"
 #include "data/prototype/entity/transport/transport_belt.h"
 #include "game/logic/transport_line_controller.h"
@@ -14,43 +13,11 @@
 
 namespace jactorio::game
 {
-	// For line_logic and line_logic_precision
-	void TestItemPositions(WorldData& world_data,
-	                       const TransportSegment* up_segment,
-	                       const TransportSegment* right_segment,
-	                       const TransportSegment* down_segment,
-	                       const TransportSegment* left_segment) {
-		// Moving left at a speed of 0.01f per update, in 250 updates
-		// Should reach end of transport line - Next update will change its direction to up
+	// Tests:
+	// - Line logic
+	// - Line properties
+	// - Item transition (to another segment)
 
-		// End of U | 5 - 2(0.7) / 0.01 = 360
-		for (int i = 0; i < 360; ++i) {
-			TransportLineLogicUpdate(world_data);
-		}
-		ASSERT_FLOAT_EQ(up_segment->right.lane.front().first.getAsDouble(), 0.f);
-		ASSERT_EQ(up_segment->right.lane.size(), 1);
-
-		// End of R | 4 - 2(0.7) / 0.01 = 260 updates
-		for (int i = 0; i < 260; ++i) {
-			TransportLineLogicUpdate(world_data);
-		}
-		ASSERT_FLOAT_EQ(right_segment->right.lane.front().first.getAsDouble(), 0.f);
-		ASSERT_EQ(right_segment->right.lane.size(), 1);
-
-		// End of D
-		for (int i = 0; i < 360; ++i) {
-			TransportLineLogicUpdate(world_data);
-		}
-		ASSERT_FLOAT_EQ(down_segment->right.lane.front().first.getAsDouble(), 0.f);
-		ASSERT_EQ(down_segment->right.lane.size(), 1);
-
-		// End of L 4 - 2(0.7)
-		for (int i = 0; i < 260; ++i) {
-			TransportLineLogicUpdate(world_data);
-		}
-		ASSERT_FLOAT_EQ(left_segment->right.lane.front().first.getAsDouble(), 0.f);
-		ASSERT_EQ(left_segment->right.lane.size(), 1);
-	}
 
 	class TransportLineControllerTest : public testing::Test
 	{
@@ -73,120 +40,11 @@ namespace jactorio::game
 		/// \brief Creates tile UniqueData for TransportSegment
 		void RegisterSegment(const Chunk::ChunkPair& world_coords,
 		                     const std::shared_ptr<TransportSegment>& segment) {
-			TestRegisterTransportSegment(worldData_, world_coords, segment, *transportBeltProto_.get());
+			TestRegisterTransportSegment(worldData_, world_coords, segment, *transportBeltProto_);
 		}
 	};
 
 	TEST_F(TransportLineControllerTest, LineLogic) {
-		// Tests that items move as expected (within a chunk)
-
-		transportBeltProto_->speed = 0.01f;
-
-		// Segments (Logic chunk must be created first)
-		const auto up_segment = std::make_shared<TransportSegment>(
-			data::Orientation::up,
-			TransportSegment::TerminationType::bend_right,
-			5);
-		const auto right_segment = std::make_shared<TransportSegment>(
-			data::Orientation::right,
-			TransportSegment::TerminationType::bend_right,
-			4);
-		const auto down_segment = std::make_shared<TransportSegment>(
-			data::Orientation::down,
-			TransportSegment::TerminationType::bend_right,
-			5);
-		auto left_segment = std::make_shared<TransportSegment>(
-			data::Orientation::left,
-			TransportSegment::TerminationType::bend_right,
-			4);
-
-		// What each transport segment empties into
-		up_segment->targetSegment    = right_segment.get();
-		right_segment->targetSegment = down_segment.get();
-		down_segment->targetSegment  = left_segment.get();
-		left_segment->targetSegment  = up_segment.get();
-
-		RegisterSegment({0, 0}, up_segment);
-		RegisterSegment({4, 0}, right_segment);
-		RegisterSegment({4, 5}, down_segment);
-		RegisterSegment({0, 5}, left_segment);
-
-		// The actual lengths of the transport segments != the indicated length as it turns earlier
-
-		// Insert item
-		left_segment->AppendItem(false, 0.f, itemProto_.get());
-
-		TestItemPositions(worldData_,
-		                  up_segment.get(), right_segment.get(),
-		                  down_segment.get(), left_segment.get());
-	}
-
-	/*
-	TEST_F(TransportLineControllerTest, LineLogicPrecision) {
-		// Tests for data type precision representing the distance between items
-
-		const auto item_proto = std::make_unique<jactorio::data::Item>();
-		const auto transport_belt_proto = std::make_unique<jactorio::data::Transport_belt>();
-		transport_belt_proto->speed = 0.01f;
-
-		// Segments (Logic chunk must be created first)
-		auto* up_segment = new jactorio::game::Transport_line_segment(
-			jactorio::data::Orientation::up,
-			jactorio::game::Transport_line_segment::terminationType::bend_right,
-			5);
-		auto* right_segment = new jactorio::game::Transport_line_segment(
-			jactorio::data::Orientation::right,
-			jactorio::game::Transport_line_segment::terminationType::bend_right,
-			4);
-		auto* down_segment = new jactorio::game::Transport_line_segment(
-			jactorio::data::Orientation::down,
-			jactorio::game::Transport_line_segment::terminationType::bend_right,
-			5);
-		auto* left_segment = new jactorio::game::Transport_line_segment(
-			jactorio::data::Orientation::left,
-			jactorio::game::Transport_line_segment::terminationType::bend_right,
-			4);
-
-		// What each transport segment empties into
-		up_segment->target_segment = right_segment;
-		right_segment->target_segment = down_segment;
-		down_segment->target_segment = left_segment;
-		left_segment->target_segment = up_segment;
-		{
-			auto& up = logic_chunk_->get_struct(jactorio::game::Logic_chunk::structLayer::transport_line)
-			                      .emplace_back(transport_belt_proto.get(), 0, 0);
-			up.unique_data = up_segment;
-
-			auto& right = logic_chunk_->get_struct(jactorio::game::Logic_chunk::structLayer::transport_line)
-			                         .emplace_back(transport_belt_proto.get(), 4, 0);
-			right.unique_data = right_segment;
-
-			auto& down = logic_chunk_->get_struct(jactorio::game::Logic_chunk::structLayer::transport_line)
-			                        .emplace_back(transport_belt_proto.get(), 4, 5);
-			down.unique_data = down_segment;
-
-			auto& left = logic_chunk_->get_struct(jactorio::game::Logic_chunk::structLayer::transport_line)
-			                        .emplace_back(transport_belt_proto.get(), 0, 5);
-			left.unique_data = left_segment;
-		}
-
-
-		// Insert item
-		left_segment->append_item(false, 0.f, item_proto.get());
-
-		// Should manage to make 100 000 laps
-		for (int i = 0; i < 100000; ++i) {
-			test_item_positions(world_data_, up_segment, right_segment, down_segment, left_segment);
-
-			if (HasFatalFailure()) {
-				printf("Precision failed on lap %d/100000\n", i + 1);
-				FAIL();
-			}
-		}
-	}
-	*/
-
-	TEST_F(TransportLineControllerTest, LineLogicFast) {
 		// Same as line logic, but belts are faster (0.06), which seems to break the current logic at the time of writing
 		const auto j_belt_speed = 0.06f;
 
@@ -393,44 +251,6 @@ namespace jactorio::game
 		EXPECT_FLOAT_EQ(right_segment->left.lane[1].first.getAsDouble(), 0.25f);
 	}
 
-	TEST_F(TransportLineControllerTest, LineLogicTransitionStraight) {
-		// Transferring from a straight segment traveling left to another one traveling left
-		/*
-		 * < ------ LEFT (1) ------		< ------ LEFT (2) -------
-		 */
-
-		transportBeltProto_->speed = 0.01f;
-
-		auto segment_1 = std::make_shared<TransportSegment>(
-			data::Orientation::left,
-			TransportSegment::TerminationType::straight,
-			4);
-		auto segment_2 = std::make_shared<TransportSegment>(
-			data::Orientation::left,
-			TransportSegment::TerminationType::straight,
-			4);
-
-		segment_2->targetSegment = segment_1.get();
-
-		RegisterSegment({0, 0}, segment_1);
-		RegisterSegment({3, 0}, segment_2);
-
-		// Insert item on left + right side
-		segment_2->AppendItem(true, 0.02f, itemProto_.get());
-		segment_2->AppendItem(false, 0.02f, itemProto_.get());
-
-		// Travel to the next belt in 0.02 / 0.01 + 1 updates
-		for (int i = 0; i < 3; ++i) {
-			TransportLineLogicUpdate(worldData_);
-		}
-
-		EXPECT_EQ(segment_2->left.lane.size(), 0);
-		EXPECT_EQ(segment_2->right.lane.size(), 0);
-		// 3.99 tiles from the end of this transport line
-		EXPECT_FLOAT_EQ(segment_1->left.lane[0].first.getAsDouble(), 3.99);
-		EXPECT_FLOAT_EQ(segment_1->right.lane[0].first.getAsDouble(), 3.99);
-	}
-
 	TEST_F(TransportLineControllerTest, LineLogicStopAtEndOfLine) {
 		// When no target_segment is provided:
 		// First Item will stop at the end of line (Distance is 0)
@@ -531,7 +351,53 @@ namespace jactorio::game
 		EXPECT_FLOAT_EQ(up_segment->right.lane.front().first.getAsDouble(), 0);
 	}
 
-	TEST_F(TransportLineControllerTest, LineLogicItemSpacing) {
+	TEST_F(TransportLineControllerTest, LineLogicNewSegmentAddedAhead) {
+		//     2      1
+		// < ----- < -----
+		
+		transportBeltProto_->speed = 0.04f;
+
+		// Segments (Logic chunk must be created first)
+		auto left_segment = std::make_shared<TransportSegment>(
+			data::Orientation::left,
+			TransportSegment::TerminationType::straight,
+			2);
+
+		RegisterSegment({2, 1}, left_segment);
+
+		// One item stopped, one still moving
+		left_segment->AppendItem(true, 0, itemProto_.get());
+		TransportLineLogicUpdate(worldData_);
+		EXPECT_EQ(left_segment.get()->left.index, 0);
+
+		left_segment->AppendItem(true, 2, itemProto_.get());
+		TransportLineLogicUpdate(worldData_);
+		EXPECT_EQ(left_segment.get()->left.index, 1);
+
+
+		// ======================================================================
+		const auto left_segment_2 = std::make_shared<TransportSegment>(
+			data::Orientation::left,
+			TransportSegment::TerminationType::straight,
+			1);
+
+		left_segment->targetSegment = left_segment_2.get();
+
+		RegisterSegment({1, 1}, left_segment_2);
+
+		// Update neighboring segments as a new segment was placed
+		transportBeltProto_->OnNeighborUpdate(worldData_, 
+											  {1, 1}, {2, 1},
+											  data::Orientation::right);
+
+		EXPECT_EQ(left_segment.get()->left.index, 0);
+	}
+
+
+	// ======================================================================
+	// Line properties
+
+	TEST_F(TransportLineControllerTest, ItemSpacing) {
 		// A minimum distance of kItemSpacing is maintained between items
 
 		auto right_segment = std::make_shared<TransportSegment>(
@@ -547,6 +413,115 @@ namespace jactorio::game
 		// Check that second item has a minimum distance of kItemSpacing
 		EXPECT_FLOAT_EQ(right_segment->left.lane[0].first.getAsDouble(), 0.f);
 		EXPECT_FLOAT_EQ(right_segment->left.lane[1].first.getAsDouble(), jactorio::game::kItemSpacing);
+	}
+
+	TEST_F(TransportLineControllerTest, BackItemDistance) {
+		/*
+		 * ^
+		 * |
+		 * |
+		 * 
+		 * ^
+		 * |
+		 * |
+		 */
+
+		transportBeltProto_->speed = 0.05;
+
+
+		// Segments (Logic chunk must be created first)
+		auto up_segment_1 = std::make_shared<TransportSegment>(data::Orientation::up,
+		                                                       TransportSegment::TerminationType::straight,
+		                                                       1);
+		auto up_segment_2 = std::make_shared<TransportSegment>(data::Orientation::up,
+		                                                       TransportSegment::TerminationType::straight,
+		                                                       1);
+
+		up_segment_2->targetSegment = up_segment_1.get();
+
+		RegisterSegment({0, 0}, up_segment_1);
+		RegisterSegment({0, 1}, up_segment_2);
+
+		up_segment_2->AppendItem(true, 0.05, itemProto_.get());
+		EXPECT_FLOAT_EQ(up_segment_2->left.backItemDistance.getAsDouble(), 0.05);
+
+		TransportLineLogicUpdate(worldData_);
+		EXPECT_FLOAT_EQ(up_segment_2->left.backItemDistance.getAsDouble(), 0);
+
+		// Segment 1
+		TransportLineLogicUpdate(worldData_);
+		EXPECT_FLOAT_EQ(up_segment_2->left.backItemDistance.getAsDouble(), 0);
+
+		EXPECT_FLOAT_EQ(up_segment_1->left.backItemDistance.getAsDouble(), 0.95);  // First segment now
+
+		for (int i = 0; i < 19; ++i) {
+			TransportLineLogicUpdate(worldData_);
+		}
+		EXPECT_FLOAT_EQ(up_segment_1->left.backItemDistance.getAsDouble(), 0);
+
+		// Remains at 0
+		TransportLineLogicUpdate(worldData_);
+		EXPECT_FLOAT_EQ(up_segment_1->left.backItemDistance.getAsDouble(), 0);
+
+
+		// ======================================================================
+		// Fill the first segment up to 4 items
+		up_segment_1->AppendItem(true, 0, itemProto_.get());
+		up_segment_1->AppendItem(true, 0, itemProto_.get());
+		up_segment_1->AppendItem(true, 0, itemProto_.get());
+		EXPECT_FLOAT_EQ(up_segment_1->left.backItemDistance.getAsDouble(), 0.75);
+
+
+		// Will not enter since segment 1 is full
+		up_segment_2->AppendItem(true, 0.05, itemProto_.get());
+		TransportLineLogicUpdate(worldData_);
+		TransportLineLogicUpdate(worldData_);
+		TransportLineLogicUpdate(worldData_);
+		EXPECT_FLOAT_EQ(up_segment_1->left.backItemDistance.getAsDouble(), 0.75);
+		EXPECT_FLOAT_EQ(up_segment_2->left.backItemDistance.getAsDouble(), 0);
+	}
+
+
+	// ======================================================================
+	// Item transition
+	
+
+	TEST_F(TransportLineControllerTest, LineLogicTransitionStraight) {
+		// Transferring from a straight segment traveling left to another one traveling left
+		/*
+		 * < ------ LEFT (1) ------		< ------ LEFT (2) -------
+		 */
+
+		transportBeltProto_->speed = 0.01f;
+
+		auto segment_1 = std::make_shared<TransportSegment>(
+			data::Orientation::left,
+			TransportSegment::TerminationType::straight,
+			4);
+		auto segment_2 = std::make_shared<TransportSegment>(
+			data::Orientation::left,
+			TransportSegment::TerminationType::straight,
+			4);
+
+		segment_2->targetSegment = segment_1.get();
+
+		RegisterSegment({0, 0}, segment_1);
+		RegisterSegment({3, 0}, segment_2);
+
+		// Insert item on left + right side
+		segment_2->AppendItem(true, 0.02f, itemProto_.get());
+		segment_2->AppendItem(false, 0.02f, itemProto_.get());
+
+		// Travel to the next belt in 0.02 / 0.01 + 1 updates
+		for (int i = 0; i < 3; ++i) {
+			TransportLineLogicUpdate(worldData_);
+		}
+
+		EXPECT_EQ(segment_2->left.lane.size(), 0);
+		EXPECT_EQ(segment_2->right.lane.size(), 0);
+		// 3.99 tiles from the end of this transport line
+		EXPECT_FLOAT_EQ(segment_1->left.lane[0].first.getAsDouble(), 3.99);
+		EXPECT_FLOAT_EQ(segment_1->right.lane[0].first.getAsDouble(), 3.99);
 	}
 
 	TEST_F(TransportLineControllerTest, LineLogicTransitionSideLeft) {
@@ -754,111 +729,99 @@ namespace jactorio::game
 
 	}
 
-	TEST_F(TransportLineControllerTest, LineLogicNewSegmentAddedAhead) {
-		//     2      1
-		// < ----- < -----
-		
-		transportBeltProto_->speed = 0.04f;
+	TEST_F(TransportLineControllerTest, SideOnlyBendingTermination) {
+		//   v
+		// < < <
+		//   ^
 
-		// Segments (Logic chunk must be created first)
+		transportBeltProto_->speed = 0.06;
+		
 		auto left_segment = std::make_shared<TransportSegment>(
 			data::Orientation::left,
-			TransportSegment::TerminationType::straight,
-			2);
-
-		RegisterSegment({2, 1}, left_segment);
-
-		// One item stopped, one still moving
-		left_segment->AppendItem(true, 0, itemProto_.get());
-		TransportLineLogicUpdate(worldData_);
-		EXPECT_EQ(left_segment.get()->left.index, 0);
-
-		left_segment->AppendItem(true, 2, itemProto_.get());
-		TransportLineLogicUpdate(worldData_);
-		EXPECT_EQ(left_segment.get()->left.index, 1);
-
+			TransportSegment::TerminationType::bend_right,
+			4);
+		left_segment->itemOffset = 1;
+		RegisterSegment({2, 2}, left_segment);
 
 		// ======================================================================
-		auto left_segment_2 = std::make_shared<TransportSegment>(
-			data::Orientation::left,
-			TransportSegment::TerminationType::straight,
+
+		auto down_segment = std::make_shared<TransportSegment>(
+			data::Orientation::down,
+			TransportSegment::TerminationType::right_only,
 			1);
 
-		left_segment->targetSegment = left_segment_2.get();
+		down_segment->targetSegment = left_segment.get();
+		down_segment->targetInsertOffset = 2;
 
-		RegisterSegment({1, 1}, left_segment_2);
-
-		// Update neighboring segments as a new segment was placed
-		transportBeltProto_->OnNeighborUpdate(worldData_, 
-											  {1, 1}, {2, 1},
-											  data::Orientation::right);
-
-		EXPECT_EQ(left_segment.get()->left.index, 0);
-	}
-
-	TEST_F(TransportLineControllerTest, BackItemDistance) {
-		/*
-		 * ^
-		 * |
-		 * |
-		 * 
-		 * ^
-		 * |
-		 * |
-		 */
-
-		transportBeltProto_->speed = 0.05;
+		RegisterSegment({3, 1}, down_segment);
 
 
-		// Segments (Logic chunk must be created first)
-		auto up_segment_1 = std::make_shared<TransportSegment>(data::Orientation::up,
-		                                                       TransportSegment::TerminationType::straight,
-		                                                       1);
-		auto up_segment_2 = std::make_shared<TransportSegment>(data::Orientation::up,
-		                                                       TransportSegment::TerminationType::straight,
-		                                                       1);
+		// Left lane
 
-		up_segment_2->targetSegment = up_segment_1.get();
 
-		RegisterSegment({0, 0}, up_segment_1);
-		RegisterSegment({0, 1}, up_segment_2);
-
-		up_segment_2->AppendItem(true, 0.05, itemProto_.get());
-		EXPECT_FLOAT_EQ(up_segment_2->left.backItemDistance.getAsDouble(), 0.05);
-
+		down_segment->AppendItem(true, 0, itemProto_.get());
+		
 		TransportLineLogicUpdate(worldData_);
-		EXPECT_FLOAT_EQ(up_segment_2->left.backItemDistance.getAsDouble(), 0);
+		
+		ASSERT_EQ(left_segment->right.lane.size(), 1);
+		
+		// (line offset) + itemOffset - belt speed
+		EXPECT_FLOAT_EQ(left_segment->right.lane[0].first.getAsDouble(), (0.3f + 1.f + 0.7f) + 1.f - 0.06f);
 
-		// Segment 1
+		
+		// Right lane
+
+		
+		left_segment->right.lane.clear();
+
+		down_segment->AppendItem(false, 0, itemProto_.get());
+		
 		TransportLineLogicUpdate(worldData_);
-		EXPECT_FLOAT_EQ(up_segment_2->left.backItemDistance.getAsDouble(), 0);
-
-		EXPECT_FLOAT_EQ(up_segment_1->left.backItemDistance.getAsDouble(), 0.95);  // First segment now
-
-		for (int i = 0; i < 19; ++i) {
-			TransportLineLogicUpdate(worldData_);
-		}
-		EXPECT_FLOAT_EQ(up_segment_1->left.backItemDistance.getAsDouble(), 0);
-
-		// Remains at 0
-		TransportLineLogicUpdate(worldData_);
-		EXPECT_FLOAT_EQ(up_segment_1->left.backItemDistance.getAsDouble(), 0);
+		
+		ASSERT_EQ(left_segment->right.lane.size(), 1);
+		
+		EXPECT_FLOAT_EQ(left_segment->right.lane[0].first.getAsDouble(), (0.3f + 1.f + 0.3f) + 1.f - 0.06f);
 
 
 		// ======================================================================
-		// Fill the first segment up to 4 items
-		up_segment_1->AppendItem(true, 0, itemProto_.get());
-		up_segment_1->AppendItem(true, 0, itemProto_.get());
-		up_segment_1->AppendItem(true, 0, itemProto_.get());
-		EXPECT_FLOAT_EQ(up_segment_1->left.backItemDistance.getAsDouble(), 0.75);
+
+		auto up_segment = std::make_shared<TransportSegment>(
+			data::Orientation::up,
+			TransportSegment::TerminationType::left_only,
+			1);
+
+		up_segment->targetSegment = left_segment.get();
+		up_segment->targetInsertOffset = 2;
+
+		RegisterSegment({3, 3}, up_segment);
 
 
-		// Will not enter since segment 1 is full
-		up_segment_2->AppendItem(true, 0.05, itemProto_.get());
+		// Left lane
+
+
+		up_segment->AppendItem(true, 0, itemProto_.get());
+		
 		TransportLineLogicUpdate(worldData_);
+		
+		ASSERT_EQ(left_segment->left.lane.size(), 1);
+		
+		// (line offset) + itemOffset - belt speed
+		EXPECT_FLOAT_EQ(left_segment->left.lane[0].first.getAsDouble(), (0.7f + 1.f + 0.3f) + 1.f - 0.06f);
+
+		
+		// Right lane
+
+		
+		left_segment->left.lane.clear();
+
+		up_segment->AppendItem(false, 0, itemProto_.get());
+		
 		TransportLineLogicUpdate(worldData_);
-		TransportLineLogicUpdate(worldData_);
-		EXPECT_FLOAT_EQ(up_segment_1->left.backItemDistance.getAsDouble(), 0.75);
-		EXPECT_FLOAT_EQ(up_segment_2->left.backItemDistance.getAsDouble(), 0);
+		
+		ASSERT_EQ(left_segment->left.lane.size(), 1);
+		
+		EXPECT_FLOAT_EQ(left_segment->left.lane[0].first.getAsDouble(), (0.7f + 1.f + 0.7f) + 1.f - 0.06f);
+
+
 	}
 }

--- a/test/game/logic/transport_segmentTests.cpp
+++ b/test/game/logic/transport_segmentTests.cpp
@@ -323,14 +323,14 @@ namespace jactorio::game
 		{
 			segment_->itemOffset = 0;
 
-			TransportSegment::BeginOffsetT o = 3;
+			TransportSegment::FloatOffsetT o = 3;
 			segment_->GetOffsetAbs(o);
 			EXPECT_FLOAT_EQ(o, 3.f);
 		}
 		{
 			segment_->itemOffset = 3;
 
-			TransportSegment::BeginOffsetT o = 3;
+			TransportSegment::FloatOffsetT o = 3;
 			segment_->GetOffsetAbs(o);
 			EXPECT_FLOAT_EQ(o, 0.f);
 		}
@@ -338,7 +338,7 @@ namespace jactorio::game
 		{
 			segment_->itemOffset = -2;
 
-			TransportSegment::BeginOffsetT o = 3;
+			TransportSegment::IntOffsetT o = 3;
 			segment_->GetOffsetAbs(o);
 			EXPECT_FLOAT_EQ(o, 5.f);
 		}


### PR DESCRIPTION
Transport line / segment bugfixes

Rendering:
- Fixed incorrect item rendering on upwards segment bending left

Prototypes:
- Fixed invalid range check of transport line prototype speed

Game:
- Fixed invalid calculation of itemOffset for non straight terminating segments
- Fixed items occasionally getting stuck on segments
