### PR TITLE
Improve/inserter

### DIFF
--- a/data/base/prototypes/entity/inserters.py
+++ b/data/base/prototypes/entity/inserters.py
@@ -1,7 +1,9 @@
 import jactorioData as j
 
 
-def addInserter(name, worldSprite, itemSprite, rotationSpeed, tileReach):
+def addInserter(name, itemSprite,
+                worldSprite, handSprite, armSprite,
+                rotationSpeed, tileReach):
     (j.Inserter(name)
         .pickupTime(0.1)
         .rotationSpeed(rotationSpeed)
@@ -17,6 +19,14 @@ def addInserter(name, worldSprite, itemSprite, rotationSpeed, tileReach):
                 .frames(1)
                 .invertSetFrame(True)
         )
+        .handSprite(
+            j.Sprite()
+                .load(handSprite)
+        )
+        .armSprite(
+            j.Sprite()
+                .load(armSprite)
+        )
 
         .item(
             j.Item(name + "-item")
@@ -29,19 +39,22 @@ def addInserter(name, worldSprite, itemSprite, rotationSpeed, tileReach):
 
 
 addInserter("basic-inserter",
-            "base/graphics/entity/inserter/inserter-platform.png",
             "base/graphics/icon/inserter.png",
-            14.4,
-            1)
+            worldSprite="base/graphics/entity/inserter/inserter-platform.png",
+            handSprite="base/graphics/entity/inserter/inserter-hand-open.png",
+            armSprite="base/graphics/entity/inserter/inserter-hand-base.png",
+            rotationSpeed=14.4, tileReach=1)
 
 addInserter("fast-inserter",
-            "base/graphics/entity/fast-inserter/fast-inserter-platform.png",
             "base/graphics/icon/fast-inserter.png",
-            20.8,
-            1)
+            worldSprite="base/graphics/entity/fast-inserter/fast-inserter-platform.png",
+            handSprite="base/graphics/entity/fast-inserter/fast-inserter-hand-open.png",
+            armSprite="base/graphics/entity/fast-inserter/fast-inserter-hand-base.png",
+            rotationSpeed=20.8, tileReach=1)
 
 addInserter("long-handed-inserter",
-            "base/graphics/entity/long-handed-inserter/long-handed-inserter-platform.png",
             "base/graphics/icon/long-handed-inserter.png",
-            18.8,
-            2)
+            worldSprite="base/graphics/entity/long-handed-inserter/long-handed-inserter-platform.png",
+            handSprite="base/graphics/entity/long-handed-inserter/long-handed-inserter-hand-open.png",
+            armSprite="base/graphics/entity/long-handed-inserter/long-handed-inserter-hand-base.png",
+            rotationSpeed=18.8, tileReach=2)

--- a/include/core/data_type.h
+++ b/include/core/data_type.h
@@ -25,11 +25,14 @@ namespace jactorio
 	constexpr int kGameHertz = 60;  // 60 updates per second
 
 
-	using WorldCoordAxis = int;
+	using WorldCoordAxis = int32_t;
 	using WorldCoord = core::Position2<WorldCoordAxis>;
 
 	using ChunkCoordAxis = int32_t;
 	using ChunkCoord = core::Position2<ChunkCoordAxis>;
+
+	/// Offset from top left of chunk
+	using OverlayOffsetAxis = float;
 
 	
 	using UvPositionT = core::QuadPosition<core::Position2<float>>;

--- a/include/core/data_type.h
+++ b/include/core/data_type.h
@@ -4,6 +4,7 @@
 #define JACTORIO_INCLUDE_CORE_DATA_TYPE_H
 #pragma once
 
+#include <cstdint>
 #include <tuple>
 #include <unordered_map>
 

--- a/include/data/prototype/entity/inserter.h
+++ b/include/data/prototype/entity/inserter.h
@@ -50,6 +50,11 @@ namespace jactorio::data
 	public:
 		PROTOTYPE_CATEGORY(inserter);
 
+		/// Part closer to the base
+		PYTHON_PROP_I(Inserter, Sprite*, armSprite, nullptr);
+		/// The hand holding the item
+		PYTHON_PROP_I(Inserter, Sprite*, handSprite, nullptr);
+
 		///
 		/// \brief Degrees to rotate per tick 
 		/// \remark For Python API use only
@@ -71,6 +76,10 @@ namespace jactorio::data
 
 		// ======================================================================
 
+		void OnRDrawUniqueData(renderer::RendererLayer& layer, const SpriteUvCoordsT& uv_coords,
+		                      const core::Position2<float>& pixel_offset,
+		                      const UniqueDataBase* unique_data) const override;
+
 		J_NODISCARD Sprite::SetT OnRGetSpriteSet(Orientation orientation, game::WorldData& world_data,
 		                                         const WorldCoord& world_coords) const override;
 
@@ -91,6 +100,8 @@ namespace jactorio::data
 
 		void PostLoadValidate(const PrototypeManager&) const override {
 			J_DATA_ASSERT(tileReach != 0, "Invalid tileReach, > 0");
+			J_DATA_ASSERT(armSprite != nullptr, "Arm sprite not provided");
+			J_DATA_ASSERT(handSprite != nullptr, "Hand sprite not provided");
 		}
 
 		void ValidatedPostLoad() override {

--- a/include/data/prototype/entity/transport_line.h
+++ b/include/data/prototype/entity/transport_line.h
@@ -68,9 +68,6 @@ namespace jactorio::data
 		///
 		/// \brief Converts lineOrientation to placementOrientation
 		static Orientation ToOrientation(LineOrientation line_orientation);
-
-		void OnDrawUniqueData(renderer::RendererLayer& layer, const SpriteUvCoordsT& uv_coords,
-		                      float x_offset, float y_offset) const override;
 	};
 
 
@@ -116,6 +113,10 @@ namespace jactorio::data
 
 		// ======================================================================
 		// Game events
+
+		void OnRDrawUniqueData(renderer::RendererLayer& layer, const SpriteUvCoordsT& uv_coords,
+		                       const core::Position2<float>& pixel_offset,
+		                       const UniqueDataBase* unique_data) const override;
 
 		J_NODISCARD Sprite::SetT OnRGetSpriteSet(Orientation orientation, game::WorldData& world_data,
 		                                         const WorldCoord& world_coords) const override;

--- a/include/data/prototype/interface/renderable.h
+++ b/include/data/prototype/interface/renderable.h
@@ -47,13 +47,6 @@ namespace jactorio::data
 
 	public:
 		Sprite::SetT set = 0;
-
-		///
-		/// \param pixel_offset_x Pixels to top left of current tile
-		/// \param pixel_offset_y Pixels to top left of current tile
-		virtual void OnDrawUniqueData(renderer::RendererLayer& layer, const SpriteUvCoordsT& uv_coords,
-		                              float pixel_offset_x, float pixel_offset_y) const {
-		}
 	};
 
 	///
@@ -90,6 +83,12 @@ namespace jactorio::data
 		virtual bool OnRShowGui(game::PlayerData& player_data, const PrototypeManager& data_manager,
 		                        game::ChunkTileLayer* tile_layer) const = 0;
 
+		///
+		/// \param pixel_offset Pixels to top left of current tile
+		virtual void OnRDrawUniqueData(renderer::RendererLayer& layer, const SpriteUvCoordsT& uv_coords,
+		                               const core::Position2<float>& pixel_offset,
+		                               const UniqueDataBase* unique_data) const {
+		}
 
 	protected:
 		// ======================================================================

--- a/include/data/pybind/pybind_bindings.h
+++ b/include/data/pybind/pybind_bindings.h
@@ -207,6 +207,8 @@ PYBIND11_EMBEDDED_MODULE(jactorioData, m) {
 
 	// Inserter
 	PYBIND_DATA_CLASS(Inserter, Inserter, HealthEntity)
+		PYBIND_PROP(Inserter, handSprite)
+		PYBIND_PROP(Inserter, armSprite)
 		PYBIND_PROP_S(Inserter, rotationSpeed, rotationSpeedFloat, Set_rotationSpeedFloat)
 		PYBIND_PROP(Inserter, tileReach);
 

--- a/include/game/event/game_events.h
+++ b/include/game/event/game_events.h
@@ -4,7 +4,11 @@
 #define JACTORIO_INCLUDE_GAME_EVENT_GAME_EVENTS_H
 #pragma once
 
-#include "event_base.h"
+#include <functional>
+#include <vector>
+
+#include "game/event/event_base.h"
+#include "renderer/display_window.h"
 
 namespace jactorio::game
 {
@@ -26,7 +30,13 @@ namespace jactorio::game
 	class RendererTickEvent final : public EventBase
 	{
 	public:
-		RendererTickEvent() = default;
+		using DisplayWindowContainerT = std::vector<std::reference_wrapper<renderer::DisplayWindow>>;
+
+		explicit RendererTickEvent(const DisplayWindowContainerT& window)
+			: windows(window) {
+		}
+
+		const DisplayWindowContainerT& windows;
 
 		EVENT_TYPE(renderer_tick)
 		EVENT_CATEGORY(application)

--- a/include/game/logic/item_logistics.h
+++ b/include/game/logic/item_logistics.h
@@ -196,7 +196,7 @@ namespace jactorio::game
 		GetPickupFunc getPickupFunc_ = nullptr;
 
 	private:
-		static std::pair<bool, double> GetBeltPickupProps(const PickupParams& args);
+		static std::pair<bool, TransportLineOffset> GetBeltPickupProps(const PickupParams& args);
 	};
 }
 

--- a/include/game/logic/item_logistics.h
+++ b/include/game/logic/item_logistics.h
@@ -6,6 +6,7 @@
 
 #include "data/prototype/type.h"
 #include "data/prototype/entity/assembly_machine.h"
+#include "data/prototype/entity/transport_line.h"
 #include "data/prototype/item/item.h"
 #include "game/logic/logic_data.h"
 #include "game/world/world_data.h"
@@ -68,35 +69,51 @@ namespace jactorio::game
 		bool Initialize(const WorldData& world_data,
 		                data::UniqueDataBase& target_unique_data, const WorldCoord& world_coord) override;
 
+
+		struct DropOffParams
+		{
+			LogicData& logicData;
+			const data::Item::Stack& itemStack;
+			/// Entity to drop into
+			data::UniqueDataBase& uniqueData;
+			data::Orientation orientation;
+		};
+
 		///
 		///	 \brief Insert provided item at destination
 		bool DropOff(LogicData& logic_data, const data::Item::Stack& item_stack) const {
 			assert(targetUniqueData_);
-			return (this->*dropFunc_)(logic_data, item_stack, *targetUniqueData_, orientation_);
+			assert(dropFunc_);
+			return (this->*dropFunc_)({logic_data, item_stack, *targetUniqueData_, orientation_});
+		}
+
+		///
+		///	 \return true if dropoff can ever possible at the specified location 
+		J_NODISCARD bool CanDropOff(LogicData& logic_data, const data::Item*& item) const {
+			assert(targetUniqueData_);
+			assert(canDropFunc_);
+			return (this->*canDropFunc_)({logic_data, {item, 0}, *targetUniqueData_, orientation_});
 		}
 
 	protected:
 		// Dropoff functions
 
-		virtual bool InsertContainerEntity(LogicData& logic_data,
-		                                   const data::Item::Stack& item_stack,
-		                                   data::UniqueDataBase& unique_data,
-		                                   data::Orientation orientation) const;
+		J_NODISCARD virtual bool CanInsertContainerEntity(const DropOffParams& args) const;
+		virtual bool InsertContainerEntity(const DropOffParams& args) const;
 
-		virtual bool InsertTransportBelt(LogicData& logic_data,
-		                                 const data::Item::Stack& item_stack,
-		                                 data::UniqueDataBase& unique_data,
-		                                 data::Orientation orientation) const;
+		J_NODISCARD virtual bool CanInsertTransportBelt(const DropOffParams& args) const;
+		virtual bool InsertTransportBelt(const DropOffParams& args) const;
 
-		virtual bool InsertAssemblyMachine(LogicData& logic_data,
-		                                   const data::Item::Stack& item_stack,
-		                                   data::UniqueDataBase& unique_data,
-		                                   data::Orientation orientation) const;
+		J_NODISCARD virtual bool CanInsertAssemblyMachine(const DropOffParams& args) const;
+		virtual bool InsertAssemblyMachine(const DropOffParams& args) const;
+
 
 		using DropOffFunc = decltype(&ItemDropOff::InsertContainerEntity);
+		using CanDropOffFunc = decltype(&ItemDropOff::CanInsertContainerEntity);
 
 		/// \brief Chosen function for inserting at destination
-		DropOffFunc dropFunc_ = nullptr;
+		DropOffFunc dropFunc_       = nullptr;
+		CanDropOffFunc canDropFunc_ = nullptr;
 	};
 
 	///
@@ -105,6 +122,7 @@ namespace jactorio::game
 	{
 		/// Success, picked up stack
 		using PickupReturn = std::pair<bool, data::Item::Stack>;
+		using GetPickupReturn = const data::Item*;
 
 	public:
 		explicit InserterPickup(const data::Orientation orientation)
@@ -118,6 +136,18 @@ namespace jactorio::game
 		bool Initialize(const WorldData& world_data,
 		                data::UniqueDataBase& target_unique_data, const WorldCoord& world_coord) override;
 
+
+		/// \remark Picks up items when at max deg
+		struct PickupParams
+		{
+			LogicData& logicData;
+			data::ProtoUintT inserterTileReach;
+			const data::RotationDegree& degree;
+			data::Item::StackCount amount;
+			data::UniqueDataBase& uniqueData;
+			data::Orientation orientation;
+		};
+
 		///
 		///	 \brief Insert provided item at destination
 		PickupReturn Pickup(LogicData& logic_data,
@@ -125,49 +155,48 @@ namespace jactorio::game
 		                    const data::RotationDegree& degree,
 		                    const data::Item::StackCount amount) const {
 			assert(targetUniqueData_);
-			return (this->*pickupFunc_)(logic_data,
-			                            inserter_tile_reach, degree, amount, *targetUniqueData_, orientation_);
+			assert(pickupFunc_);
+			return (this->*pickupFunc_)({
+				logic_data,
+				inserter_tile_reach, degree, amount, *targetUniqueData_, orientation_
+			});
+		}
+
+		///
+		/// \return Item which will picked up by Pickup()
+		J_NODISCARD GetPickupReturn GetPickup(LogicData& logic_data,
+		                                      const data::ProtoUintT inserter_tile_reach,
+		                                      const data::RotationDegree& degree) const {
+			assert(targetUniqueData_);
+			assert(getPickupFunc_);
+			return (this->*getPickupFunc_)({
+				logic_data,
+				inserter_tile_reach, degree, 1, *targetUniqueData_, orientation_
+			});
 		}
 
 	protected:
-		///
-		/// \remark Picks up items when at max deg
-		/// \param unique_data Unique data of container to be picked up from 
-		virtual PickupReturn PickupContainerEntity(LogicData& logic_data,
-		                                           data::ProtoUintT inserter_tile_reach,
-		                                           const data::RotationDegree& degree,
-		                                           data::Item::StackCount amount,
-		                                           data::UniqueDataBase& unique_data,
-		                                           data::Orientation orientation) const;
+		J_NODISCARD virtual GetPickupReturn GetPickupContainerEntity(const PickupParams& args) const;
+		virtual PickupReturn PickupContainerEntity(const PickupParams& args) const;
 
-		///
-		/// \remark Will only pickup 1 from transport lines regardless of amount
-		/// \param unique_data Unique data of transport belt to be picked up from 
-		virtual PickupReturn PickupTransportBelt(LogicData& logic_data,
-		                                         data::ProtoUintT inserter_tile_reach,
-		                                         const data::RotationDegree& degree,
-		                                         data::Item::StackCount amount,
-		                                         data::UniqueDataBase& unique_data,
-		                                         data::Orientation orientation) const;
+		J_NODISCARD virtual GetPickupReturn GetPickupTransportBelt(const PickupParams& args) const;
+		virtual PickupReturn PickupTransportBelt(const PickupParams& args) const;
 
-		///
-		/// \remark Picks up items when at max deg
-		/// \param unique_data Unique data of transport belt to be picked up from 
-		virtual PickupReturn PickupAssemblyMachine(LogicData& logic_data,
-		                                           data::ProtoUintT inserter_tile_reach,
-		                                           const data::RotationDegree& degree,
-		                                           data::Item::StackCount amount,
-		                                           data::UniqueDataBase& unique_data,
-		                                           data::Orientation orientation) const;
+		J_NODISCARD virtual GetPickupReturn GetPickupAssemblyMachine(const PickupParams& args) const;
+		virtual PickupReturn PickupAssemblyMachine(const PickupParams& args) const;
 
 		///
 		/// \returns true if at maximum inserter degree
 		static bool IsAtMaxDegree(const data::RotationDegree& degree);
 
 		using PickupFunc = decltype(&InserterPickup::PickupContainerEntity);
+		using GetPickupFunc = decltype(&InserterPickup::GetPickupContainerEntity);
 
-		/// \brief Function for inserting at destination, from one below
-		PickupFunc pickupFunc_ = nullptr;
+		PickupFunc pickupFunc_       = nullptr;
+		GetPickupFunc getPickupFunc_ = nullptr;
+
+	private:
+		static std::pair<bool, double> GetBeltPickupProps(const PickupParams& args);
 	};
 }
 

--- a/include/game/logic/transport_segment.h
+++ b/include/game/logic/transport_segment.h
@@ -46,6 +46,8 @@ namespace jactorio::game
 
 		bool TryInsertItem(FloatOffsetT offset, const data::Item* item, IntOffsetT item_offset);
 
+		J_NODISCARD std::pair<size_t, TransportLineItem> GetItem(FloatOffsetT offset,
+		                                                         FloatOffsetT epsilon = kItemWidth / 2) const;
 		const data::Item* TryPopItem(FloatOffsetT offset, FloatOffsetT epsilon = kItemWidth / 2);
 
 		// ======================================================================
@@ -175,7 +177,14 @@ namespace jactorio::game
 		bool TryInsertItemAbs(bool left_side, FloatOffsetT offset, const data::Item* item);
 
 		///
-		/// \brief Finds item at offset within epsilon inclusive
+		/// \brief Finds item at offset within epsilon inclusive, <deque index, TransportLineItem>
+		/// \return .second.second is nullptr if no items were found
+		J_NODISCARD std::pair<size_t, TransportLineItem> GetItemAbs(bool left_side,
+		                                                            FloatOffsetT offset,
+		                                                            FloatOffsetT epsilon = kItemWidth / 2) const;
+
+		///
+		/// \brief Finds and removes item at offset within epsilon inclusive
 		/// \return nullptr if no items were found
 		const data::Item* TryPopItemAbs(bool left_side, FloatOffsetT offset, FloatOffsetT epsilon = kItemWidth / 2);
 

--- a/include/game/logic/transport_segment.h
+++ b/include/game/logic/transport_segment.h
@@ -40,11 +40,11 @@ namespace jactorio::game
 		// Item insertion 
 		// See TransportSegment for function documentation
 
-		void AppendItem(FloatOffsetT offset, const data::Item* item);
+		void AppendItem(FloatOffsetT offset, const data::Item& item);
 
-		void InsertItem(FloatOffsetT offset, const data::Item* item, IntOffsetT item_offset);
+		void InsertItem(FloatOffsetT offset, const data::Item& item, IntOffsetT item_offset);
 
-		bool TryInsertItem(FloatOffsetT offset, const data::Item* item, IntOffsetT item_offset);
+		bool TryInsertItem(FloatOffsetT offset, const data::Item& item, IntOffsetT item_offset);
 
 		J_NODISCARD std::pair<size_t, TransportLineItem> GetItem(FloatOffsetT offset,
 		                                                         FloatOffsetT epsilon = kItemWidth / 2) const;
@@ -145,23 +145,53 @@ namespace jactorio::game
 		/// \return true if left size is not empty and has a valid index
 		J_NODISCARD bool IsActive(bool left_side) const;
 
+		///
+		/// \brief Deducts tile length offset to get offset based on lane length
+		/// \param target_segment_ttype If deducting termination of current segment's target is unnecessary, use straight
+		///
+		/// Since the length of segments is the tile length, it must be deducted to get the lane length to accurately insert,
+		/// remove and any other operation on segments
+		static void ApplyTerminationDeduction(bool is_left,
+		                                      TerminationType segment_ttype, TerminationType target_segment_ttype,
+		                                      TransportLineOffset& offset);
+		template <bool IsLeftLane>
+		static void ApplyTerminationDeduction(TerminationType segment_ttype, TerminationType target_segment_ttype,
+		                                      TransportLineOffset& offset);
+
+		static void ApplyLeftTerminationDeduction(TerminationType segment_ttype, TerminationType target_segment_ttype,
+		                                          TransportLineOffset& offset);
+		static void ApplyRightTerminationDeduction(TerminationType segment_ttype, TerminationType target_segment_ttype,
+		                                           TransportLineOffset& offset);
+
 		// Item insertion 
 
 		///
 		/// \brief Appends item onto the specified side of a belt behind the last item
 		/// \param offset Number of tiles to offset from previous item or the end of the transport line segment when there are no items
-		void AppendItem(bool left_side, FloatOffsetT offset, const data::Item* item);
+		void AppendItem(bool left_side, FloatOffsetT offset, const data::Item& item);
 
 		///
 		/// \brief Inserts the item onto the specified belt side at the offset from the beginning of the transport line
 		/// \param offset Distance from beginning of transport line
-		void InsertItem(bool left_side, FloatOffsetT offset, const data::Item* item);
+		void InsertItem(bool left_side, FloatOffsetT offset, const data::Item& item);
 
 		///
 		/// \brief Attempts to insert the item onto the specified belt side at the offset from the beginning of the transport line
 		/// \param offset Distance from beginning of transport line
 		/// \return false if unsuccessful
-		bool TryInsertItem(bool left_side, FloatOffsetT offset, const data::Item* item);
+		bool TryInsertItem(bool left_side, FloatOffsetT offset, const data::Item& item);
+
+		///
+		/// \brief Finds item at offset within epsilon upper and lower bounds inclusive, <deque index, TransportLineItem>
+		/// \return .second.second is nullptr if no items were found
+		J_NODISCARD std::pair<size_t, TransportLineItem> GetItem(bool left_side,
+		                                                         FloatOffsetT offset,
+		                                                         FloatOffsetT epsilon = kItemWidth / 2) const;
+
+		///
+		/// \brief Finds and removes item at offset within epsilon inclusive
+		/// \return nullptr if no items were found
+		const data::Item* TryPopItem(bool left_side, FloatOffsetT offset, FloatOffsetT epsilon = kItemWidth / 2);
 
 
 		// Item insertion with itemOffset
@@ -172,21 +202,10 @@ namespace jactorio::game
 
 		J_NODISCARD bool CanInsertAbs(bool left_side, const TransportLineOffset& start_offset);
 
-		void InsertItemAbs(bool left_side, FloatOffsetT offset, const data::Item* item);
+		void InsertItemAbs(bool left_side, FloatOffsetT offset, const data::Item& item);
 
-		bool TryInsertItemAbs(bool left_side, FloatOffsetT offset, const data::Item* item);
+		bool TryInsertItemAbs(bool left_side, FloatOffsetT offset, const data::Item& item);
 
-		///
-		/// \brief Finds item at offset within epsilon inclusive, <deque index, TransportLineItem>
-		/// \return .second.second is nullptr if no items were found
-		J_NODISCARD std::pair<size_t, TransportLineItem> GetItemAbs(bool left_side,
-		                                                            FloatOffsetT offset,
-		                                                            FloatOffsetT epsilon = kItemWidth / 2) const;
-
-		///
-		/// \brief Finds and removes item at offset within epsilon inclusive
-		/// \return nullptr if no items were found
-		const data::Item* TryPopItemAbs(bool left_side, FloatOffsetT offset, FloatOffsetT epsilon = kItemWidth / 2);
 
 		///
 		/// \brief Adjusts provided value such that InsertItem(, offset, ) is at the correct location
@@ -199,6 +218,17 @@ namespace jactorio::game
 		void GetOffsetAbs(IntOffsetT& val) const;
 		void GetOffsetAbs(FloatOffsetT& val) const;
 	};
+
+	template <bool IsLeftLane>
+	void TransportSegment::ApplyTerminationDeduction(const TerminationType segment_ttype, const TerminationType target_segment_ttype,
+	                                                 TransportLineOffset& offset) {
+		if constexpr (IsLeftLane) {
+			ApplyLeftTerminationDeduction(segment_ttype, target_segment_ttype, offset);
+		}
+		else {
+			ApplyRightTerminationDeduction(segment_ttype, target_segment_ttype, offset);
+		}
+	}
 }
 
 

--- a/include/game/world/overlay_element.h
+++ b/include/game/world/overlay_element.h
@@ -31,9 +31,6 @@ namespace jactorio::game
 		static constexpr float kZPosMultiplier = 0.01f;
 
 	public:
-		/// Offset from top left of chunk
-		using OffsetT = float;
-
 		/*
 		OverlayElement(const data::Sprite& sprite,
 		               const core::Position2<PositionT>& position,
@@ -43,21 +40,21 @@ namespace jactorio::game
 		*/
 
 		OverlayElement(const data::Sprite& sprite,
-		               const core::Position2<OffsetT>& position,
-		               const core::Position2<OffsetT>& size,
+		               const core::Position2<OverlayOffsetAxis>& position,
+		               const core::Position2<OverlayOffsetAxis>& size,
 		               const OverlayLayer layer)
-			: OverlayElement(sprite, core::Position3<OffsetT>{position, ToZPosition(layer)}, size) {
+			: OverlayElement(sprite, core::Position3<OverlayOffsetAxis>{position, ToZPosition(layer)}, size) {
 		}
 
 		OverlayElement(const data::Sprite& sprite,
-		               const core::Position3<OffsetT>& position,
-		               const core::Position2<OffsetT>& size)
+		               const core::Position3<OverlayOffsetAxis>& position,
+		               const core::Position2<OverlayOffsetAxis>& size)
 			: sprite(&sprite), position(position), size(size) {
 		}
 
 		// ======================================================================
 
-		void SetZPosition(const OffsetT z_pos) {
+		void SetZPosition(const OverlayOffsetAxis z_pos) {
 			position.z = z_pos;
 		}
 
@@ -66,7 +63,7 @@ namespace jactorio::game
 			SetZPosition(ToZPosition(layer));
 		}
 
-		J_NODISCARD static OffsetT ToZPosition(const OverlayLayer layer) noexcept {
+		J_NODISCARD static OverlayOffsetAxis ToZPosition(const OverlayLayer layer) noexcept {
 			return kDefaultZPos + kZPosMultiplier * static_cast<float>(layer);
 		}
 
@@ -77,10 +74,10 @@ namespace jactorio::game
 		data::Sprite::SetT spriteSet = 0;
 
 		/// Distance (tiles) from top left of chunk to top left of sprite + z value
-		core::Position3<OffsetT> position;
+		core::Position3<OverlayOffsetAxis> position;
 
 		/// Distance (tiles) the sprite spans
-		core::Position2<OffsetT> size;
+		core::Position2<OverlayOffsetAxis> size;
 	};
 }
 

--- a/include/game/world/overlay_element.h
+++ b/include/game/world/overlay_element.h
@@ -15,6 +15,7 @@ namespace jactorio::game
 	{
 		// A separate layer is only needed when it needs to be accessed independently, otherwise join together in single layer
 		general = 0,
+		debug,
 		count_
 	};
 

--- a/include/game/world/world_data.h
+++ b/include/game/world/world_data.h
@@ -61,7 +61,7 @@ namespace jactorio::game
 
 		///
 		/// \brief Converts world coordinate to overlay element coordinates
-		static OverlayElement::OffsetT ToOverlayCoord(WorldCoordAxis world_coord);
+		static OverlayOffsetAxis ToOverlayCoord(WorldCoordAxis world_coord);
 
 
 		// World access

--- a/include/renderer/rendering/data_renderer.h
+++ b/include/renderer/rendering/data_renderer.h
@@ -4,14 +4,19 @@
 #define JACTORIO_RENDERER_RENDERING_DATA_RENDERER_H
 #pragma once
 
+#include "data/prototype/entity/inserter.h"
 #include "data/prototype/interface/renderable.h"
 #include "game/logic/transport_segment.h"
 
 namespace jactorio::renderer
 {
 	void DrawTransportSegmentItems(RendererLayer& layer, const SpriteUvCoordsT& uv_coords,
-	                               float x_offset, float y_offset,
+	                               const core::Position2<float>& pixel_offset,
 	                               game::TransportSegment& line_segment);
+
+	void DrawInserterArm(RendererLayer& layer, const SpriteUvCoordsT& uv_coords,
+	                     const core::Position2<float>& pixel_offset,
+	                     const data::Inserter& inserter_proto, const data::InserterData& inserter_data);
 }
 
 #endif // JACTORIO_RENDERER_RENDERING_DATA_RENDERER_H

--- a/include/renderer/rendering/renderer.h
+++ b/include/renderer/rendering/renderer.h
@@ -72,14 +72,19 @@ namespace jactorio::renderer
 		///
 		/// \brief Faster non range checked get into spritemapCoords_
 		/// \remark Ensure key always exists
-		J_NODISCARD const SpriteUvCoordsT::mapped_type& GetSpriteUvCoords(const SpriteUvCoordsT::key_type key) const noexcept {
+		J_NODISCARD static const SpriteUvCoordsT::mapped_type& GetSpriteUvCoords(const SpriteUvCoordsT& map,
+		                                                                         const SpriteUvCoordsT::key_type key) noexcept {
 			try {
-				return const_cast<SpriteUvCoordsT&>(*spritemapCoords_)[key];
+				return const_cast<SpriteUvCoordsT&>(map)[key];
 			}
 			catch (std::exception&) {
 				assert(false);  // Should not throw
 				std::terminate();
 			}
+		}
+
+		J_NODISCARD const SpriteUvCoordsT::mapped_type& GetSpriteUvCoords(const SpriteUvCoordsT::key_type key) const noexcept {
+			return GetSpriteUvCoords(*spritemapCoords_, key);
 		}
 
 		///

--- a/src/data/prototype/entity/inserter.cpp
+++ b/src/data/prototype/entity/inserter.cpp
@@ -2,10 +2,19 @@
 
 #include "data/prototype/entity/inserter.h"
 
+#include "renderer/rendering/data_renderer.h"
+
 using namespace jactorio;
 
+void data::Inserter::OnRDrawUniqueData(renderer::RendererLayer& layer, const SpriteUvCoordsT& uv_coords,
+                                       const core::Position2<float>& pixel_offset,
+                                       const UniqueDataBase* unique_data) const {
+	DrawInserterArm(layer, uv_coords, pixel_offset,
+	                *this, *static_cast<const InserterData*>(unique_data));
+}
+
 data::Sprite::SetT data::Inserter::OnRGetSpriteSet(const Orientation orientation,
-												   game::WorldData&,
+                                                   game::WorldData&,
                                                    const WorldCoord&) const {
 	switch (orientation) {
 

--- a/src/data/prototype/entity/transport_line.cpp
+++ b/src/data/prototype/entity/transport_line.cpp
@@ -38,22 +38,6 @@ data::Orientation data::TransportLineData::ToOrientation(const LineOrientation l
 	}
 }
 
-void data::TransportLineData::OnDrawUniqueData(renderer::RendererLayer& layer, const SpriteUvCoordsT& uv_coords,
-                                               const float x_offset, const float y_offset) const {
-	// Only draw for the head of segments
-	if (lineSegment->terminationType == game::TransportSegment::TerminationType::straight &&
-		lineSegmentIndex != 0)
-		return;
-
-	if (lineSegment->terminationType != game::TransportSegment::TerminationType::straight &&
-		lineSegmentIndex != 1)
-		return;
-
-	DrawTransportSegmentItems(layer, uv_coords,
-	                          x_offset, y_offset,
-	                          *this->lineSegment);
-}
-
 //
 //
 //
@@ -155,6 +139,25 @@ std::shared_ptr<game::TransportSegment>* data::TransportLine::GetTransportSegmen
 	}
 
 	return nullptr;
+}
+
+void data::TransportLine::OnRDrawUniqueData(renderer::RendererLayer& layer, const SpriteUvCoordsT& uv_coords,
+                                            const core::Position2<float>& pixel_offset,
+                                            const UniqueDataBase* unique_data) const {
+	auto& line_data = *static_cast<const TransportLineData*>(unique_data);
+
+	// Only draw for the head of segments
+	if (line_data.lineSegment->terminationType == game::TransportSegment::TerminationType::straight &&
+		line_data.lineSegmentIndex != 0)
+		return;
+
+	if (line_data.lineSegment->terminationType != game::TransportSegment::TerminationType::straight &&
+		line_data.lineSegmentIndex != 1)
+		return;
+
+	DrawTransportSegmentItems(layer, uv_coords,
+	                          pixel_offset,
+	                          *line_data.lineSegment);
 }
 
 data::Sprite::SetT data::TransportLine::OnRGetSpriteSet(const Orientation orientation, game::WorldData& world_data,

--- a/src/data/prototype/item/recipe.cpp
+++ b/src/data/prototype/item/recipe.cpp
@@ -69,11 +69,14 @@ void jactorio::data::Recipe::PostLoadValidate(const PrototypeManager& data_manag
 	J_DATA_ASSERT(!ingredients.empty(), "No ingredients specified for recipe");
 	for (const auto& ingredient : ingredients) {
 		J_DATA_ASSERT(!ingredient.first.empty(), "Empty ingredient internal name specifier");
-		J_DATA_ASSERT_F(data_manager.DataRawGet<Item>(ingredient.first),
-		                "Ingredient %s does not exist",
-		                ingredient.first.c_str());
+
+		const auto* ingredient_item = data_manager.DataRawGet<Item>(ingredient.first);
+		J_DATA_ASSERT_F(ingredient_item, "Ingredient %s does not exist", ingredient.first.c_str());
 
 		J_DATA_ASSERT(ingredient.second > 0, "Ingredient required amount minimum is 1");
+		J_DATA_ASSERT_F(ingredient.second <= ingredient_item->stackSize,
+		                "Ingredient required amount %d exceeds max stack size of ingredient %d",
+						ingredient.second, ingredient_item->stackSize);
 	}
 
 	J_DATA_ASSERT(!product.first.empty(), "No product specified for recipe");

--- a/src/game/logic/inserter_controller.cpp
+++ b/src/game/logic/inserter_controller.cpp
@@ -104,7 +104,7 @@ void ProcessInserterPickup(const PickupQueue& pickup_queue, game::LogicData& log
 
 		// Do not pick up item if it cannot be dropped off
 		if (!inserter_data.dropoff.CanDropOff(logic_data, to_be_picked_item))
-			return;
+			continue;
 
 
 		const auto result = inserter_data.pickup.Pickup(logic_data,

--- a/src/game/logic/inserter_controller.cpp
+++ b/src/game/logic/inserter_controller.cpp
@@ -28,6 +28,8 @@ void InserterUpdate(game::LogicData& logic_data,
                     const data::Inserter& inserter_proto, data::InserterData& inserter_data) {
 	using namespace game;
 
+	assert(inserter_proto.rotationSpeed.getAsDouble() != 0);
+
 	switch (inserter_data.status) {
 
 	case data::InserterData::Status::dropoff:
@@ -49,10 +51,22 @@ void InserterUpdate(game::LogicData& logic_data,
 		if (inserter_data.rotationDegree > data::ToRotationDegree(kMaxInserterDegree)) {
 			inserter_data.rotationDegree = kMaxInserterDegree;
 
+			constexpr int pickup_amount = 1;
+
+			const auto* to_be_picked_item =
+				inserter_data.pickup.GetPickup(logic_data,
+				                               inserter_proto.tileReach,
+				                               inserter_data.rotationDegree);
+
+			// Do not pick up item if it cannot be dropped off
+			if (!inserter_data.dropoff.CanDropOff(logic_data, to_be_picked_item))
+				return;
+
+
 			const auto result = inserter_data.pickup.Pickup(logic_data,
 			                                                inserter_proto.tileReach,
 			                                                inserter_data.rotationDegree,
-			                                                1);
+			                                                pickup_amount);
 			if (result.first) {
 				inserter_data.heldItem = result.second;
 

--- a/src/game/logic/inserter_controller.cpp
+++ b/src/game/logic/inserter_controller.cpp
@@ -2,6 +2,8 @@
 
 #include "game/logic/inserter_controller.h"
 
+#include <vector>
+
 #include "data/prototype/entity/inserter.h"
 
 using namespace jactorio;
@@ -24,54 +26,49 @@ double game::GetInserterArmLength(const core::TIntDegree degree, const uint8_t t
 }
 
 
-void InserterUpdate(game::LogicData& logic_data,
-                    const data::Inserter& inserter_proto, data::InserterData& inserter_data) {
+// ======================================================================
+
+
+// Inserters are updated in stages together so that logic order does not affect inserter behavior
+// E.g Inserter1 drop off             , inserter2 picks up | 1 logic update
+//     Inserter2 has nothing to pickup, inserter1 drop off | 1 logic update
+
+struct InserterUpdateProps
+{
+	const data::Inserter& proto;
+	data::InserterData& data;
+};
+
+using DropoffQueue = std::vector<InserterUpdateProps>;
+using PickupQueue = std::vector<InserterUpdateProps>;
+
+///
+/// \brief Rotates inserters, queues inserters awaiting dropoff and pickup handling
+void RotateInserters(DropoffQueue& dropoff_queue, PickupQueue& pickup_queue,
+                     const InserterUpdateProps& props) {
 	using namespace game;
 
-	assert(inserter_proto.rotationSpeed.getAsDouble() != 0);
+	assert(props.proto.rotationSpeed.getAsDouble() != 0);
 
-	switch (inserter_data.status) {
+	switch (props.data.status) {
 
 	case data::InserterData::Status::dropoff:
-		inserter_data.rotationDegree -= inserter_proto.rotationSpeed;
-		if (inserter_data.rotationDegree <= data::ToRotationDegree(kMinInserterDegree)) {
-			inserter_data.rotationDegree = 0;  // Prevents underflow if the inserter sits idle for a long time
+		props.data.rotationDegree -= props.proto.rotationSpeed;
 
-			if (inserter_data.dropoff.DropOff(logic_data, inserter_data.heldItem)) {
-				inserter_data.status = data::InserterData::Status::pickup;
-			}
+		if (props.data.rotationDegree <= data::ToRotationDegree(kMinInserterDegree)) {
+			props.data.rotationDegree = 0;  // Prevents underflow if the inserter sits idle for a long time
+			dropoff_queue.push_back(props);
 		}
 
 		return;
 
 	case data::InserterData::Status::pickup:
 		// Rotate the inserter
-		inserter_data.rotationDegree += inserter_proto.rotationSpeed;
+		props.data.rotationDegree += props.proto.rotationSpeed;
 
-		if (inserter_data.rotationDegree > data::ToRotationDegree(kMaxInserterDegree)) {
-			inserter_data.rotationDegree = kMaxInserterDegree;
-
-			constexpr int pickup_amount = 1;
-
-			const auto* to_be_picked_item =
-				inserter_data.pickup.GetPickup(logic_data,
-				                               inserter_proto.tileReach,
-				                               inserter_data.rotationDegree);
-
-			// Do not pick up item if it cannot be dropped off
-			if (!inserter_data.dropoff.CanDropOff(logic_data, to_be_picked_item))
-				return;
-
-
-			const auto result = inserter_data.pickup.Pickup(logic_data,
-			                                                inserter_proto.tileReach,
-			                                                inserter_data.rotationDegree,
-			                                                pickup_amount);
-			if (result.first) {
-				inserter_data.heldItem = result.second;
-
-				inserter_data.status = data::InserterData::Status::dropoff;
-			}
+		if (props.data.rotationDegree > data::ToRotationDegree(kMaxInserterDegree)) {
+			props.data.rotationDegree = kMaxInserterDegree;  // Prevents overflow
+			pickup_queue.push_back(props);
 		}
 
 		return;
@@ -79,9 +76,54 @@ void InserterUpdate(game::LogicData& logic_data,
 	default:
 		assert(false);
 	}
+
+}
+
+void ProcessInserterDropoff(const DropoffQueue& dropoff_queue, game::LogicData& logic_data) {
+	for (const auto& inserter_prop : dropoff_queue) {
+		auto& inserter_data = inserter_prop.data;
+
+		if (inserter_data.dropoff.DropOff(logic_data, inserter_data.heldItem)) {
+			inserter_data.status = data::InserterData::Status::pickup;
+		}
+	}
+
+}
+
+void ProcessInserterPickup(const PickupQueue& pickup_queue, game::LogicData& logic_data) {
+	for (const auto& inserter_prop : pickup_queue) {
+		auto& inserter_data        = inserter_prop.data;
+		const auto& inserter_proto = inserter_prop.proto;
+
+		constexpr int pickup_amount = 1;
+
+		const auto* to_be_picked_item =
+			inserter_data.pickup.GetPickup(logic_data,
+			                               inserter_proto.tileReach,
+			                               inserter_data.rotationDegree);
+
+		// Do not pick up item if it cannot be dropped off
+		if (!inserter_data.dropoff.CanDropOff(logic_data, to_be_picked_item))
+			return;
+
+
+		const auto result = inserter_data.pickup.Pickup(logic_data,
+		                                                inserter_proto.tileReach,
+		                                                inserter_data.rotationDegree,
+		                                                pickup_amount);
+		if (result.first) {
+			inserter_data.heldItem = result.second;
+
+			inserter_data.status = data::InserterData::Status::dropoff;
+		}
+	}
+
 }
 
 void game::InserterLogicUpdate(WorldData& world_data, LogicData& logic_data) {
+	DropoffQueue dropoff_queue{};
+	PickupQueue pickup_queue{};
+
 	for (auto* chunk : world_data.LogicGetChunks()) {
 		for (auto* tile_layer : chunk->GetLogicGroup(Chunk::LogicGroup::inserter)) {
 			auto* inserter_data = tile_layer->GetUniqueData<data::InserterData>();
@@ -90,7 +132,10 @@ void game::InserterLogicUpdate(WorldData& world_data, LogicData& logic_data) {
 			const auto* proto_data = tile_layer->GetPrototypeData<data::Inserter>();
 			assert(proto_data);
 
-			InserterUpdate(logic_data, *proto_data, *inserter_data);
+			RotateInserters(dropoff_queue, pickup_queue, {*proto_data, *inserter_data});
 		}
 	}
+
+	ProcessInserterDropoff(dropoff_queue, logic_data);
+	ProcessInserterPickup(pickup_queue, logic_data);
 }

--- a/src/game/logic/item_logistics.cpp
+++ b/src/game/logic/item_logistics.cpp
@@ -316,9 +316,9 @@ game::InserterPickup::GetPickupReturn game::InserterPickup::GetPickupTransportBe
 game::InserterPickup::PickupReturn game::InserterPickup::PickupTransportBelt(const PickupParams& args) const {
 	auto& line_data = static_cast<data::TransportLineData&>(args.uniqueData);
 
-	const auto props         = GetBeltPickupProps(args);
-	const bool use_line_left = props.first;
-	const auto pickup_offset = props.second;
+	const auto props          = GetBeltPickupProps(args);
+	bool use_line_left        = props.first;
+	const auto& pickup_offset = props.second;
 
 	const data::Item* item;
 
@@ -331,8 +331,12 @@ game::InserterPickup::PickupReturn game::InserterPickup::PickupTransportBelt(con
 
 
 	try_pickup_item(use_line_left);
-	if (item == nullptr) {  // Try picking up from other lane if preferred lane fails
-		try_pickup_item(!use_line_left);
+	if (item == nullptr) {  
+		// Try picking up from other lane if preferred lane fails
+		// use_line_left itself must be inverted so the handling after an item was picked up utilizes the correct lane
+		use_line_left = !use_line_left;
+
+		try_pickup_item(use_line_left);
 	}
 
 	if (item != nullptr) {

--- a/src/game/logic/item_logistics.cpp
+++ b/src/game/logic/item_logistics.cpp
@@ -25,14 +25,17 @@ bool game::ItemDropOff::Initialize(const WorldData& world_data,
 	switch (entity->Category()) {
 	case data::DataCategory::container_entity:
 		dropFunc_ = &ItemDropOff::InsertContainerEntity;
+		canDropFunc_ = &ItemDropOff::CanInsertContainerEntity;
 		break;
 
 	case data::DataCategory::transport_belt:
 		dropFunc_ = &ItemDropOff::InsertTransportBelt;
+		canDropFunc_ = &ItemDropOff::CanInsertTransportBelt;
 		break;
 
 	case data::DataCategory::assembly_machine:
 		dropFunc_ = &ItemDropOff::InsertAssemblyMachine;
+		canDropFunc_ = &ItemDropOff::CanInsertAssemblyMachine;
 		break;
 
 	default:
@@ -52,29 +55,33 @@ bool game::ItemDropOff::Initialize(const WorldData& world_data,
 	                  world_coord.x, world_coord.y);
 }
 
-bool game::ItemDropOff::InsertContainerEntity(LogicData&,
-                                              const data::Item::Stack& item_stack, data::UniqueDataBase& unique_data,
-                                              data::Orientation) const {
-	auto& container_data = static_cast<data::ContainerEntityData&>(unique_data);
-	if (!CanAddStack(container_data.inventory, item_stack).first)
-		return false;
-
-	AddStack(container_data.inventory, item_stack);
+bool game::ItemDropOff::CanInsertContainerEntity(const DropOffParams&) const {
 	return true;
 }
 
-bool game::ItemDropOff::InsertTransportBelt(LogicData&,
-                                            const data::Item::Stack& item_stack, data::UniqueDataBase& unique_data,
-                                            const data::Orientation orientation) const {
-	assert(item_stack.count == 1);  // Can only insert 1 at a time
+bool game::ItemDropOff::InsertContainerEntity(const DropOffParams& args) const {
+	auto& container_data = static_cast<data::ContainerEntityData&>(args.uniqueData);
+	if (!CanAddStack(container_data.inventory, args.itemStack).first)
+		return false;
 
-	auto& line_data = static_cast<data::TransportLineData&>(unique_data);
+	AddStack(container_data.inventory, args.itemStack);
+	return true;
+}
+
+bool game::ItemDropOff::CanInsertTransportBelt(const DropOffParams&) const {
+	return true;
+}
+
+bool game::ItemDropOff::InsertTransportBelt(const DropOffParams& args) const {
+	assert(args.itemStack.count == 1);  // Can only insert 1 at a time
+
+	auto& line_data = static_cast<data::TransportLineData&>(args.uniqueData);
 
 	bool use_line_left = false;
 	// Decide whether to add item to left side or right side
 	switch (line_data.lineSegment->direction) {
 	case data::Orientation::up:
-		switch (orientation) {
+		switch (args.orientation) {
 		case data::Orientation::up:
 			break;
 		case data::Orientation::right:
@@ -92,7 +99,7 @@ bool game::ItemDropOff::InsertTransportBelt(LogicData&,
 		break;
 
 	case data::Orientation::right:
-		switch (orientation) {
+		switch (args.orientation) {
 		case data::Orientation::up:
 		case data::Orientation::right:
 			break;
@@ -109,7 +116,7 @@ bool game::ItemDropOff::InsertTransportBelt(LogicData&,
 		break;
 
 	case data::Orientation::down:
-		switch (orientation) {
+		switch (args.orientation) {
 		case data::Orientation::up:
 			return false;
 		case data::Orientation::right:
@@ -126,7 +133,7 @@ bool game::ItemDropOff::InsertTransportBelt(LogicData&,
 		break;
 
 	case data::Orientation::left:
-		switch (orientation) {
+		switch (args.orientation) {
 		case data::Orientation::up:
 			use_line_left = true;
 			break;
@@ -150,27 +157,41 @@ bool game::ItemDropOff::InsertTransportBelt(LogicData&,
 	constexpr double insertion_offset = 0.5;
 	return line_data.lineSegment->TryInsertItem(use_line_left,
 	                                            line_data.lineSegmentIndex + insertion_offset,
-	                                            item_stack.item);
+	                                            args.itemStack.item);
 }
 
-bool game::ItemDropOff::InsertAssemblyMachine(LogicData& logic_data,
-                                              const data::Item::Stack& item_stack, data::UniqueDataBase& unique_data,
-                                              data::Orientation) const {
-	assert(item_stack.item);
-	assert(item_stack.count > 0);
+bool game::ItemDropOff::CanInsertAssemblyMachine(const DropOffParams& args) const {
+	auto& machine_data = static_cast<data::AssemblyMachineData&>(args.uniqueData);
 
-	auto& machine_data = static_cast<data::AssemblyMachineData&>(unique_data);
+	// No recipe
+	if (machine_data.GetRecipe() == nullptr)
+		return false;
 
 	for (auto& slot : machine_data.ingredientInv) {
-		if (slot.filter == item_stack.item) {
-			if (slot.count + item_stack.count > item_stack.item->stackSize)
+		if (slot.filter == args.itemStack.item)
+			return true;
+	}
+
+	return false;
+}
+
+bool game::ItemDropOff::InsertAssemblyMachine(const DropOffParams& args) const {
+	assert(args.itemStack.item);
+	assert(args.itemStack.count > 0);
+
+	auto& machine_data = static_cast<data::AssemblyMachineData&>(args.uniqueData);
+
+	for (auto& slot : machine_data.ingredientInv) {
+		if (slot.filter == args.itemStack.item) {
+			if (slot.count + args.itemStack.count > args.itemStack.item->stackSize)
 				continue;
 
-			slot.item = item_stack.item;
-			slot.count += item_stack.count;
+			slot.item = args.itemStack.item;
+			slot.count += args.itemStack.count;
 
 			assert(targetProtoData_);
-			static_cast<const data::AssemblyMachine*>(targetProtoData_)->TryBeginCrafting(logic_data, machine_data);
+			static_cast<const data::AssemblyMachine*>(targetProtoData_)
+				->TryBeginCrafting(args.logicData, machine_data);
 			return true;
 		}
 	}
@@ -192,14 +213,17 @@ bool game::InserterPickup::Initialize(const WorldData& world_data,
 	switch (entity->Category()) {
 	case data::DataCategory::container_entity:
 		pickupFunc_ = &InserterPickup::PickupContainerEntity;
+		getPickupFunc_ = &InserterPickup::GetPickupContainerEntity;
 		break;
 
 	case data::DataCategory::transport_belt:
 		pickupFunc_ = &InserterPickup::PickupTransportBelt;
+		getPickupFunc_ = &InserterPickup::GetPickupTransportBelt;
 		break;
 
 	case data::DataCategory::assembly_machine:
 		pickupFunc_ = &InserterPickup::PickupAssemblyMachine;
+		getPickupFunc_ = &InserterPickup::GetPickupAssemblyMachine;
 		break;
 
 	default:
@@ -218,35 +242,105 @@ bool game::InserterPickup::Initialize(const WorldData& world_data,
 	return Initialize(world_data, target_unique_data, world_coord.x, world_coord.y);
 }
 
-game::InserterPickup::PickupReturn game::InserterPickup::PickupContainerEntity(LogicData&,
-                                                                               data::ProtoUintT,
-                                                                               const data::RotationDegree& degree,
-                                                                               const data::Item::StackCount amount,
-                                                                               data::UniqueDataBase& unique_data,
-                                                                               data::Orientation) const {
-	if (!IsAtMaxDegree(degree))
+
+game::InserterPickup::GetPickupReturn game::InserterPickup::GetPickupContainerEntity(const PickupParams& args) const {
+	auto& container = static_cast<data::ContainerEntityData&>(args.uniqueData);
+	return GetFirstItem(container.inventory);
+}
+
+game::InserterPickup::PickupReturn game::InserterPickup::PickupContainerEntity(const PickupParams& args) const {
+	if (!IsAtMaxDegree(args.degree))
 		return {false, {}};
 
-	auto& container = static_cast<data::ContainerEntityData&>(unique_data);
+	auto& container = static_cast<data::ContainerEntityData&>(args.uniqueData);
 
 
 	const auto* target_item = GetFirstItem(container.inventory);
 
-	return {RemoveInvItem(container.inventory, target_item, amount), {target_item, amount}};
+	return {RemoveInvItem(container.inventory, target_item, args.amount), {target_item, args.amount}};
 }
 
-game::InserterPickup::PickupReturn game::InserterPickup::PickupTransportBelt(LogicData&,
-                                                                             const data::ProtoUintT inserter_tile_reach,
-                                                                             const data::RotationDegree& degree,
-                                                                             const data::Item::StackCount,
-                                                                             data::UniqueDataBase& unique_data,
-                                                                             const data::Orientation orientation) const {
-	auto& line_data = static_cast<data::TransportLineData&>(unique_data);
+
+game::InserterPickup::GetPickupReturn game::InserterPickup::GetPickupTransportBelt(const PickupParams& args) const {
+	auto& line_data = static_cast<data::TransportLineData&>(args.uniqueData);
+
+	const auto props         = GetBeltPickupProps(args);
+	const bool use_line_left = props.first;
+	const auto pickup_offset = props.second;
+
+	return line_data.lineSegment->GetItemAbs(use_line_left, pickup_offset).second.second;
+}
+
+
+game::InserterPickup::PickupReturn game::InserterPickup::PickupTransportBelt(const PickupParams& args) const {
+	auto& line_data = static_cast<data::TransportLineData&>(args.uniqueData);
+
+	const auto props         = GetBeltPickupProps(args);
+	const bool use_line_left = props.first;
+	const auto pickup_offset = props.second;
+
+	const auto* item = line_data.lineSegment->TryPopItemAbs(use_line_left, pickup_offset);
+
+	if (item != nullptr) {
+		line_data.lineSegment->GetSide(use_line_left).index = 0;
+
+		return {true, {item, 1}};
+	}
+	return {false, {}};
+}
+
+
+game::InserterPickup::GetPickupReturn game::InserterPickup::GetPickupAssemblyMachine(const PickupParams& args) const {
+	assert(args.amount > 0);
+
+	auto& machine_data = static_cast<data::AssemblyMachineData&>(args.uniqueData);
+
+	if (!machine_data.HasRecipe())
+		return nullptr;
+
+	auto& product_stack = machine_data.productInv[0];
+	return product_stack.filter;
+}
+
+game::InserterPickup::PickupReturn game::InserterPickup::PickupAssemblyMachine(const PickupParams& args) const {
+	assert(args.amount > 0);
+
+	if (!IsAtMaxDegree(args.degree))
+		return {false, {}};
+
+
+	auto& machine_data = static_cast<data::AssemblyMachineData&>(args.uniqueData);
+
+	if (!machine_data.HasRecipe())
+		return {false, {}};
+
+	auto& product_stack = machine_data.productInv[0];
+
+	// Not enough to pick up
+	if (product_stack.count < args.amount)
+		return {false, {}};
+
+	product_stack.count -= args.amount;
+
+	const auto* asm_machine = static_cast<const data::AssemblyMachine*>(targetProtoData_);
+	assert(asm_machine);
+	asm_machine->TryBeginCrafting(args.logicData, machine_data);
+
+	return {true, {product_stack.item, args.amount}};
+}
+
+
+bool game::InserterPickup::IsAtMaxDegree(const data::RotationDegree& degree) {
+	return degree == data::ToRotationDegree(kMaxInserterDegree);
+}
+
+std::pair<bool, double> game::InserterPickup::GetBeltPickupProps(const PickupParams& args) {
+	auto& line_data = static_cast<data::TransportLineData&>(args.uniqueData);
 
 	bool use_line_left = false;
 	switch (line_data.lineSegment->direction) {
 	case data::Orientation::up:
-		switch (orientation) {
+		switch (args.orientation) {
 		case data::Orientation::down:
 		case data::Orientation::left:
 			use_line_left = true;
@@ -258,7 +352,7 @@ game::InserterPickup::PickupReturn game::InserterPickup::PickupTransportBelt(Log
 		break;
 
 	case data::Orientation::right:
-		switch (orientation) {
+		switch (args.orientation) {
 		case data::Orientation::up:
 		case data::Orientation::left:
 			use_line_left = true;
@@ -270,7 +364,7 @@ game::InserterPickup::PickupReturn game::InserterPickup::PickupTransportBelt(Log
 		break;
 
 	case data::Orientation::down:
-		switch (orientation) {
+		switch (args.orientation) {
 		case data::Orientation::up:
 		case data::Orientation::right:
 			use_line_left = true;
@@ -282,7 +376,7 @@ game::InserterPickup::PickupReturn game::InserterPickup::PickupTransportBelt(Log
 		break;
 
 	case data::Orientation::left:
-		switch (orientation) {
+		switch (args.orientation) {
 		case data::Orientation::right:
 		case data::Orientation::down:
 			use_line_left = true;
@@ -298,52 +392,8 @@ game::InserterPickup::PickupReturn game::InserterPickup::PickupTransportBelt(Log
 		break;
 	}
 
-	const auto pickup_offset =
-		line_data.lineSegmentIndex +
-		GetInserterArmOffset(degree.getAsInteger(), inserter_tile_reach);
+	auto pickup_offset = line_data.lineSegmentIndex +
+		GetInserterArmOffset(args.degree.getAsInteger(), args.inserterTileReach);
 
-	const auto* item = line_data.lineSegment->TryPopItemAbs(use_line_left, pickup_offset);
-
-	if (item != nullptr) {
-		line_data.lineSegment->GetSide(use_line_left).index = 0;
-
-		return {true, {item, 1}};
-	}
-	return {false, {}};
-}
-
-game::InserterPickup::PickupReturn game::InserterPickup::PickupAssemblyMachine(LogicData& logic_data,
-                                                                               data::ProtoUintT,
-                                                                               const data::RotationDegree& degree,
-                                                                               const data::Item::StackCount amount,
-                                                                               data::UniqueDataBase& unique_data,
-                                                                               data::Orientation) const {
-	assert(amount > 0);
-
-	if (!IsAtMaxDegree(degree))
-		return {false, {}};
-
-
-	auto& machine_data = static_cast<data::AssemblyMachineData&>(unique_data);
-
-	if (!machine_data.HasRecipe())
-		return {false, {}};
-
-	auto& product_stack = machine_data.productInv[0];
-
-	// Not enough to pick up
-	if (product_stack.count < amount)
-		return {false, {}};
-
-	product_stack.count -= amount;
-
-	const auto* asm_machine = static_cast<const data::AssemblyMachine*>(targetProtoData_);
-	assert(asm_machine);
-	asm_machine->TryBeginCrafting(logic_data, machine_data);
-
-	return {true, {product_stack.item, amount}};
-}
-
-bool game::InserterPickup::IsAtMaxDegree(const data::RotationDegree& degree) {
-	return degree == data::ToRotationDegree(kMaxInserterDegree);
+	return {use_line_left, pickup_offset};
 }

--- a/src/game/logic/item_logistics.cpp
+++ b/src/game/logic/item_logistics.cpp
@@ -69,6 +69,15 @@ bool game::ItemDropOff::InsertContainerEntity(const DropOffParams& args) const {
 	return true;
 }
 
+void GetAdjustedLineOffset(const bool use_line_left, 
+						   game::TransportLineOffset& pickup_offset,
+						   const data::TransportLineData& line_data) {
+	game::TransportSegment::ApplyTerminationDeduction(use_line_left,
+	                                            line_data.lineSegment->terminationType,
+	                                            game::TransportSegment::TerminationType::straight,
+	                                            pickup_offset);
+}
+
 bool game::ItemDropOff::CanInsertTransportBelt(const DropOffParams&) const {
 	return true;
 }
@@ -155,9 +164,12 @@ bool game::ItemDropOff::InsertTransportBelt(const DropOffParams& args) const {
 		break;
 	}
 
-	constexpr double insertion_offset = 0.5;
+	constexpr double insertion_offset_base = 0.5;
+	auto offset = TransportLineOffset(line_data.lineSegmentIndex + insertion_offset_base);
+
+	GetAdjustedLineOffset(use_line_left, offset, line_data);
 	return line_data.lineSegment->TryInsertItem(use_line_left,
-	                                            line_data.lineSegmentIndex + insertion_offset,
+	                                            offset.getAsDouble(),
 	                                            *args.itemStack.item);
 }
 
@@ -274,15 +286,6 @@ game::InserterPickup::PickupReturn game::InserterPickup::PickupContainerEntity(c
 	return {RemoveInvItem(container.inventory, target_item, args.amount), {target_item, args.amount}};
 }
 
-
-void GetAdjustedLineOffset(const bool use_line_left, 
-						   game::TransportLineOffset& pickup_offset,
-						   const data::TransportLineData& line_data) {
-	game::TransportSegment::ApplyTerminationDeduction(use_line_left,
-	                                            line_data.lineSegment->terminationType,
-	                                            game::TransportSegment::TerminationType::straight,
-	                                            pickup_offset);
-}
 
 game::InserterPickup::GetPickupReturn game::InserterPickup::GetPickupTransportBelt(const PickupParams& args) const {
 	auto& line_data = static_cast<data::TransportLineData&>(args.uniqueData);

--- a/src/game/logic/item_logistics.cpp
+++ b/src/game/logic/item_logistics.cpp
@@ -294,6 +294,11 @@ game::InserterPickup::PickupReturn game::InserterPickup::PickupTransportBelt(con
 
 	const auto* item = line_data.lineSegment->TryPopItemAbs(use_line_left, pickup_offset);
 
+	// Try picking up from other lane if preferred lane fails
+	if (item == nullptr)
+		item = line_data.lineSegment->TryPopItemAbs(!use_line_left, pickup_offset);
+
+
 	if (item != nullptr) {
 		line_data.lineSegment->GetSide(use_line_left).index = 0;
 

--- a/src/game/logic/transport_segment.cpp
+++ b/src/game/logic/transport_segment.cpp
@@ -6,11 +6,13 @@
 
 #include "game/logic/transport_line_controller.h"
 
-bool jactorio::game::TransportLane::IsActive() const {
+using namespace jactorio;
+
+bool game::TransportLane::IsActive() const {
 	return !(lane.empty() || index >= lane.size());
 }
 
-bool jactorio::game::TransportLane::CanInsert(TransportLineOffset start_offset, const IntOffsetT item_offset) {
+bool game::TransportLane::CanInsert(TransportLineOffset start_offset, const IntOffsetT item_offset) {
 	start_offset += TransportLineOffset(item_offset);
 	assert(start_offset.getAsDouble() >= 0);
 
@@ -46,7 +48,7 @@ bool jactorio::game::TransportLane::CanInsert(TransportLineOffset start_offset, 
 	return offset <= start_offset;
 }
 
-void jactorio::game::TransportLane::AppendItem(FloatOffsetT offset, const data::Item* item) {
+void game::TransportLane::AppendItem(FloatOffsetT offset, const data::Item* item) {
 	// A minimum distance of item_spacing is maintained between items (AFTER the initial item)
 	if (offset < kItemSpacing && !lane.empty())
 		offset = kItemSpacing;
@@ -55,7 +57,7 @@ void jactorio::game::TransportLane::AppendItem(FloatOffsetT offset, const data::
 	backItemDistance += TransportLineOffset{offset};
 }
 
-void jactorio::game::TransportLane::InsertItem(FloatOffsetT offset, const data::Item* item, const IntOffsetT item_offset) {
+void game::TransportLane::InsertItem(FloatOffsetT offset, const data::Item* item, const IntOffsetT item_offset) {
 	offset += item_offset;
 	assert(offset >= 0);
 
@@ -93,8 +95,8 @@ loop_exit:
 	lane.emplace(it, target_offset, item);
 }
 
-bool jactorio::game::TransportLane::TryInsertItem(const FloatOffsetT offset, const data::Item* item,
-                                                  const IntOffsetT item_offset) {
+bool game::TransportLane::TryInsertItem(const FloatOffsetT offset, const data::Item* item,
+                                        const IntOffsetT item_offset) {
 	if (!CanInsert(dec::decimal_cast<kTransportLineDecimalPlace>(offset), item_offset))
 		return false;
 
@@ -106,86 +108,102 @@ bool jactorio::game::TransportLane::TryInsertItem(const FloatOffsetT offset, con
 	return true;
 }
 
-const jactorio::data::Item* jactorio::game::TransportLane::TryPopItem(const FloatOffsetT offset, const FloatOffsetT epsilon) {
-
+std::pair<size_t, game::TransportLineItem> game::TransportLane::GetItem(const FloatOffsetT offset,
+                                                                        const FloatOffsetT epsilon) const {
 	const TransportLineOffset target_offset{offset - epsilon};
 	TransportLineOffset offset_counter{0};
 
 	// Iterate past offset - epsilon
 	size_t iteration = 0;
-	for (auto& item_pair : lane) {
+	for (const auto& item_pair : lane) {
 		offset_counter += item_pair.first;
 
 		if (offset_counter >= target_offset) {
 			// Return first item if it is within upper bounds offset + epsilon
 			if (item_pair.first < TransportLineOffset(offset + epsilon)) {
-				// Adjust the next item to preserve spacing
-				if (iteration + 1 < lane.size()) {
-					lane[iteration + 1].first += item_pair.first;
-				}
-
-				const data::Item* item = item_pair.second;
-				lane.erase(lane.begin() + iteration);
-
-				return item;
+				return {iteration, item_pair};
 			}
 			// Past upper epsilon bound
-			return nullptr;
+			return {0, {}};
 		}
 
 		++iteration;
 	}
 	// Failed to meet lower epsilon
-	return nullptr;
+	return {0, {}};
+}
+
+const data::Item* game::TransportLane::TryPopItem(const FloatOffsetT offset, const FloatOffsetT epsilon) {
+	const auto result = GetItem(offset, epsilon);
+
+	if (result.second.second == nullptr)
+		return nullptr;
+
+	const auto iteration = result.first;
+	const auto item_pair = result.second;
+
+
+	if (iteration + 1 < lane.size()) {
+		lane[iteration + 1].first += item_pair.first;
+	}
+
+	lane.erase(lane.begin() + iteration);
+	return item_pair.second;
 }
 
 // ======================================================================
 
-bool jactorio::game::TransportSegment::CanInsert(const bool left_side, const TransportLineOffset& start_offset) {
+bool game::TransportSegment::CanInsert(const bool left_side, const TransportLineOffset& start_offset) {
 	return left_side ? left.CanInsert(start_offset, 0) : right.CanInsert(start_offset, 0);
 }
 
-bool jactorio::game::TransportSegment::IsActive(const bool left_side) const {
+bool game::TransportSegment::IsActive(const bool left_side) const {
 	return left_side ? left.IsActive() : right.IsActive();
 }
 
-void jactorio::game::TransportSegment::AppendItem(const bool left_side, const FloatOffsetT offset, const data::Item* item) {
+void game::TransportSegment::AppendItem(const bool left_side, const FloatOffsetT offset, const data::Item* item) {
 	left_side ? left.AppendItem(offset, item) : right.AppendItem(offset, item);
 }
 
-void jactorio::game::TransportSegment::InsertItem(const bool left_side, const FloatOffsetT offset, const data::Item* item) {
+void game::TransportSegment::InsertItem(const bool left_side, const FloatOffsetT offset, const data::Item* item) {
 	left_side ? left.InsertItem(offset, item, 0) : right.InsertItem(offset, item, 0);
 }
 
-bool jactorio::game::TransportSegment::TryInsertItem(const bool left_side, const FloatOffsetT offset, const data::Item* item) {
+bool game::TransportSegment::TryInsertItem(const bool left_side, const FloatOffsetT offset, const data::Item* item) {
 	return left_side ? left.TryInsertItem(offset, item, 0) : right.TryInsertItem(offset, item, 0);
 }
 
 // With itemOffset applied
 
-bool jactorio::game::TransportSegment::CanInsertAbs(const bool left_side, const TransportLineOffset& start_offset) {
+bool game::TransportSegment::CanInsertAbs(const bool left_side, const TransportLineOffset& start_offset) {
 	return left_side ? left.CanInsert(start_offset, itemOffset) : right.CanInsert(start_offset, itemOffset);
 }
 
-void jactorio::game::TransportSegment::InsertItemAbs(const bool left_side, const FloatOffsetT offset, const data::Item* item) {
+void game::TransportSegment::InsertItemAbs(const bool left_side, const FloatOffsetT offset, const data::Item* item) {
 	left_side ? left.InsertItem(offset, item, itemOffset) : right.InsertItem(offset, item, itemOffset);
 }
 
-bool jactorio::game::TransportSegment::TryInsertItemAbs(const bool left_side, const FloatOffsetT offset,
-                                                        const data::Item* item) {
+bool game::TransportSegment::TryInsertItemAbs(const bool left_side, const FloatOffsetT offset,
+                                              const data::Item* item) {
 	return left_side ? left.TryInsertItem(offset, item, itemOffset) : right.TryInsertItem(offset, item, itemOffset);
 }
 
-const jactorio::data::Item* jactorio::game::TransportSegment::TryPopItemAbs(const bool left_side,
-                                                                            const FloatOffsetT offset,
-                                                                            const FloatOffsetT epsilon) {
+std::pair<size_t, game::TransportLineItem> game::TransportSegment::GetItemAbs(const bool left_side,
+                                                                              const FloatOffsetT offset,
+                                                                              const FloatOffsetT epsilon) const {
+	return left_side ? left.GetItem(offset, epsilon) : right.GetItem(offset, epsilon);
+}
+
+const data::Item* game::TransportSegment::TryPopItemAbs(const bool left_side,
+                                                        const FloatOffsetT offset,
+                                                        const FloatOffsetT epsilon) {
 	return left_side ? left.TryPopItem(offset, epsilon) : right.TryPopItem(offset, epsilon);
 }
 
-void jactorio::game::TransportSegment::GetOffsetAbs(IntOffsetT& val) const {
+void game::TransportSegment::GetOffsetAbs(IntOffsetT& val) const {
 	val -= itemOffset;
 }
 
-void jactorio::game::TransportSegment::GetOffsetAbs(FloatOffsetT& val) const {
+void game::TransportSegment::GetOffsetAbs(FloatOffsetT& val) const {
 	val -= itemOffset;
 }

--- a/src/game/world/world_data.cpp
+++ b/src/game/world/world_data.cpp
@@ -172,11 +172,15 @@ void game::WorldData::LogicRegister(const Chunk::LogicGroup group, const WorldCo
 	auto* chunk = GetChunkW(world_pair);
 	assert(chunk);
 
-	logicChunks_.emplace(chunk);
-
 	auto* tile_layer = &GetTile(world_pair)->GetLayer(layer);
-	chunk->GetLogicGroup(group)
-	     .push_back(tile_layer);
+	auto& logic_group = chunk->GetLogicGroup(group);
+
+	// Already added to logic group at tile layer 
+	if (std::find(logic_group.begin(), logic_group.end(), tile_layer) != logic_group.end())
+		return;
+
+	logicChunks_.emplace(chunk);
+	chunk->GetLogicGroup(group).push_back(tile_layer);
 }
 
 void game::WorldData::LogicRemove(const Chunk::LogicGroup group, const WorldCoord& world_pair,

--- a/src/game/world/world_data.cpp
+++ b/src/game/world/world_data.cpp
@@ -30,7 +30,7 @@ ChunkCoordAxis game::WorldData::ToChunkCoord(WorldCoordAxis world_coord) {
 	return chunk_coord;
 }
 
-game::OverlayElement::OffsetT game::WorldData::ToOverlayCoord(const WorldCoordAxis world_coord) {
+OverlayOffsetAxis game::WorldData::ToOverlayCoord(const WorldCoordAxis world_coord) {
 	WorldCoordAxis val;
 
 	if (world_coord < 0) {

--- a/src/renderer/gui/gui_menus_debug.cpp
+++ b/src/renderer/gui/gui_menus_debug.cpp
@@ -70,7 +70,7 @@ void renderer::DebugMenu(game::PlayerData& player_data, const data::PrototypeMan
 		if (ImGui::Button("Clear debug overlays")) {
 			for (auto* chunk : player_data.GetPlayerWorldData().LogicGetChunks()) {
 
-				auto& object_layer = chunk->GetOverlay(game::OverlayLayer::general);
+				auto& object_layer = chunk->GetOverlay(game::OverlayLayer::debug);
 				object_layer.clear();
 			}
 		}
@@ -176,6 +176,8 @@ bool show_transport_segments     = false;
 void ShowTransportSegments(game::WorldData& world_data, const data::PrototypeManager& data_manager) {
 	using namespace jactorio;
 
+	constexpr game::OverlayLayer draw_overlay_layer = game::OverlayLayer::debug;
+
 	// Sprite representing the update point
 	const auto* sprite_stop =
 		data_manager.DataRawGet<data::Sprite>("__core__/rect-red");
@@ -197,7 +199,7 @@ void ShowTransportSegments(game::WorldData& world_data, const data::PrototypeMan
 
 	// Get all update points and add it to the chunk's objects for drawing
 	for (auto* chunk : world_data.LogicGetChunks()) {
-		auto& object_layer = chunk->GetOverlay(game::OverlayLayer::general);
+		auto& object_layer = chunk->GetOverlay(draw_overlay_layer);
 		object_layer.clear();
 
 		for (int i = 0; i < game::Chunk::kChunkArea; ++i) {
@@ -284,10 +286,10 @@ void ShowTransportSegments(game::WorldData& world_data, const data::PrototypeMan
 				outline_sprite = sprite_stop;  // None moving
 
 			object_layer.emplace_back(
-				game::OverlayElement{*direction_sprite, {pos_x, pos_y}, {segment_len_x, segment_len_y}, game::OverlayLayer::general}
+				game::OverlayElement{*direction_sprite, {pos_x, pos_y}, {segment_len_x, segment_len_y}, draw_overlay_layer}
 			);
 			object_layer.emplace_back(
-				game::OverlayElement{*outline_sprite, {pos_x, pos_y}, {segment_len_x, segment_len_y}, game::OverlayLayer::general}
+				game::OverlayElement{*outline_sprite, {pos_x, pos_y}, {segment_len_x, segment_len_y}, draw_overlay_layer}
 			);
 		}
 	}
@@ -392,12 +394,12 @@ void renderer::DebugTransportLineInfo(game::PlayerData& player_data, const data:
 		if (ImGui::Button("Append Item Left"))
 			segment.AppendItem(true,
 			                   0.2,
-			                   data_manager.DataRawGet<data::Item>(iname));
+			                   *data_manager.DataRawGet<data::Item>(iname));
 
 		if (ImGui::Button("Append Item Right"))
 			segment.AppendItem(false,
 			                   0.2,
-			                   data_manager.DataRawGet<data::Item>(iname));
+			                   *data_manager.DataRawGet<data::Item>(iname));
 
 
 		// Display items

--- a/src/renderer/gui/gui_menus_debug.cpp
+++ b/src/renderer/gui/gui_menus_debug.cpp
@@ -389,6 +389,8 @@ void renderer::DebugTransportLineInfo(game::PlayerData& player_data, const data:
 
 		ImGui::Text("Direction: %s", OrientationToStr(segment.direction));
 
+		ImGui::Text("Item update index: %d %d", segment.left.index, segment.right.index);
+
 		// Appending item
 		const std::string iname = "__base__/wooden-chest-item";
 		if (ImGui::Button("Append Item Left"))

--- a/src/renderer/rendering/data_renderer.cpp
+++ b/src/renderer/rendering/data_renderer.cpp
@@ -293,30 +293,60 @@ prepare_right:
 void renderer::DrawInserterArm(RendererLayer& layer, const SpriteUvCoordsT& uv_coords,
                                const core::Position2<OverlayOffsetAxis>& pixel_offset, const data::Inserter& inserter_proto,
                                const data::InserterData& inserter_data) {
-	const auto& uv = Renderer::GetSpriteUvCoords(uv_coords, inserter_proto.handSprite->internalId);
+	{
+		const auto& uv = Renderer::GetSpriteUvCoords(uv_coords, inserter_proto.handSprite->internalId);
 
-	constexpr int arm_width        = 2;
-	constexpr int arm_pixel_offset = (Renderer::tileWidth - arm_width) / 2;
+		constexpr float arm_width     = 0.5f;
+		constexpr float arm_pixel_offset = (Renderer::tileWidth - arm_width * Renderer::tileWidth) / 2;
 
-	// Ensures arm is always facing pickup / dropoff
-	const float rotation_offset = static_cast<float>(inserter_data.orientation) * 90;
+		// Ensures arm is always facing pickup / dropoff
+		const float rotation_offset = static_cast<float>(inserter_data.orientation) * 90;
 
-	layer.PushBack(
-		{
-			{  // Cover tile
-				{
-					pixel_offset.x + arm_pixel_offset,
-					pixel_offset.y + arm_pixel_offset
+		// Hand
+		layer.PushBack(
+			{
+				{  // Cover tile
+					{
+						pixel_offset.x + arm_pixel_offset,
+						pixel_offset.y + arm_pixel_offset
+					},
+					{
+						pixel_offset.x + Renderer::tileWidth - arm_pixel_offset,
+						pixel_offset.y + Renderer::tileWidth - arm_pixel_offset
+					}
 				},
 				{
-					pixel_offset.x + Renderer::tileWidth - arm_pixel_offset,
-					pixel_offset.y + Renderer::tileWidth - arm_pixel_offset
+					uv.topLeft,
+					uv.bottomRight
 				}
-			},
+			}, kPixelZ, static_cast<float>(inserter_data.rotationDegree.getAsDouble() + rotation_offset)
+		);
+	}
+
+	
+	// Held item
+	if (inserter_data.status == data::InserterData::Status::dropoff) {
+		constexpr float held_item_pixel_offset = (Renderer::tileWidth - Renderer::tileWidth * game::kItemWidth) / 2;
+
+		const auto& uv = Renderer::GetSpriteUvCoords(uv_coords, inserter_data.heldItem.item->sprite->internalId);
+
+		layer.PushBack(
 			{
-				uv.topLeft,
-				uv.bottomRight
-			}
-		}, kPixelZ, static_cast<float>(inserter_data.rotationDegree.getAsDouble() + rotation_offset)
-	);
+				{
+					{
+						pixel_offset.x + held_item_pixel_offset,
+						pixel_offset.y + held_item_pixel_offset
+					},
+					{
+						pixel_offset.x + Renderer::tileWidth - held_item_pixel_offset,
+						pixel_offset.y + Renderer::tileWidth - held_item_pixel_offset
+					}
+				},
+				{
+					uv.topLeft,
+					uv.bottomRight
+				}
+			}, kPixelZ
+		);
+	}
 }

--- a/src/renderer/rendering/renderer.cpp
+++ b/src/renderer/rendering/renderer.cpp
@@ -336,7 +336,7 @@ void renderer::Renderer::PrepareTileLayers(RendererLayer& r_layer, game::ChunkTi
 			ApplySpriteUvAdjustment(uv, sprite->GetCoords(unique_data->set, sprite_frame));
 
 			// Custom draw function
-			unique_data->OnDrawUniqueData(r_layer, *spritemapCoords_, pixel_pos.x, pixel_pos.y);
+			proto->OnRDrawUniqueData(r_layer, *spritemapCoords_, {pixel_pos.x, pixel_pos.y}, unique_data);
 		}
 		else {
 			const auto* sprite = proto->OnRGetSprite(0);

--- a/test/game/logic/inserter_controllerTests.cpp
+++ b/test/game/logic/inserter_controllerTests.cpp
@@ -135,7 +135,7 @@ namespace jactorio::game
 		TestRegisterTransportSegment(worldData_, {1, 2}, pickup, segment_proto);
 
 		for (int i = 0; i < 1000; ++i) {
-			pickup->AppendItem(false, 0, &item);
+			pickup->AppendItem(false, 0, item);
 		}
 
 

--- a/test/game/logic/inserter_controllerTests.cpp
+++ b/test/game/logic/inserter_controllerTests.cpp
@@ -164,4 +164,26 @@ namespace jactorio::game
 		InserterLogicUpdate(worldData_, logicData_);
 		EXPECT_EQ(inserter_data->status, data::InserterData::Status::dropoff);
 	}
+
+	TEST_F(InserterControllerTest, PickupIfCanDropOff) {
+		// Inserter will not pick up items that it can never drop off
+
+		// Cannot drop into assembly machine since it has no recipe
+		const data::AssemblyMachine asm_machine{};
+		auto& dropoff = TestSetupAssemblyMachine(worldData_, {0, 1}, asm_machine);
+
+		auto* pickup = BuildChest({3, 2}, data::Orientation::right);
+
+
+		inserterProto_.rotationSpeed = 2.1f;
+		auto& inserter_layer         = BuildInserter({2, 2}, data::Orientation::left);
+		auto* inserter_data          = inserter_layer.GetUniqueData<data::InserterData>();
+
+
+		// 
+		InserterLogicUpdate(worldData_, logicData_);
+
+		EXPECT_EQ(inserter_data->status, data::InserterData::Status::pickup);
+		EXPECT_EQ(pickup->inventory[0].count, 10);
+	}
 }

--- a/test/game/logic/item_logisticsTests.cpp
+++ b/test/game/logic/item_logisticsTests.cpp
@@ -550,12 +550,8 @@ namespace jactorio::game
 		{
 			auto line = CreateTransportLine(data::Orientation::up);
 
-			line.lineSegment->right.index = 10;
-
-			// Should set index to 0 since a item was removed
 			PickupLine(data::Orientation::up, line);
 			EXPECT_EQ(line.lineSegment->right.lane.size(), 0);
-			EXPECT_EQ(line.lineSegment->right.index, 0);
 		}
 		{
 			auto line = CreateTransportLine(data::Orientation::up);
@@ -712,8 +708,13 @@ namespace jactorio::game
 			&lineItem_
 		);
 
+		// Should set index to 0 since a item was removed
+		line.lineSegment->right.index = 10;
+
 		PickupLine(data::Orientation::up, line);
 		EXPECT_EQ(line.lineSegment->right.lane.size(), 0);
+		EXPECT_EQ(line.lineSegment->right.index, 0);
+
 
 		// Use alternative side
 		EXPECT_EQ(
@@ -724,8 +725,12 @@ namespace jactorio::game
 				}),
 			&lineItem_
 		);
+
+		line.lineSegment->left.index = 10;
+
 		PickupLine(data::Orientation::up, line);
 		EXPECT_EQ(line.lineSegment->left.lane.size(), 0);
+		EXPECT_EQ(line.lineSegment->left.index, 0);
 	}
 
 

--- a/test/game/logic/item_logisticsTests.cpp
+++ b/test/game/logic/item_logisticsTests.cpp
@@ -354,17 +354,30 @@ namespace jactorio::game
 		EXPECT_FALSE(CanInsertAssemblyMachine({logicData_, {&item, 2}, asm_data, data::Orientation::down}));
 
 
-		// Has recipe, wrong item
 		data::PrototypeManager prototype_manager{};
 
 		auto recipe_pack = TestSetupRecipe(prototype_manager);
 		asm_data.ChangeRecipe(logicData_, prototype_manager, &recipe_pack.recipe);
 
+		// Has recipe, wrong item
 		EXPECT_FALSE(CanInsertAssemblyMachine({logicData_, {&item, 2}, asm_data, data::Orientation::down}));
 
-
 		// Has recipe, correct item
-		EXPECT_TRUE(CanInsertAssemblyMachine({logicData_, {recipe_pack.item1, 2000}, asm_data, data::Orientation::down}));
+		DropOffParams args{logicData_, {recipe_pack.item1, 2000}, asm_data, data::Orientation::down};
+		EXPECT_TRUE(CanInsertAssemblyMachine(args));
+
+		// Exceeds the max percentage that a slot can be filled
+		asm_data.ingredientInv[0].count = 2;
+		EXPECT_FALSE(CanInsertAssemblyMachine(args));
+
+		// Exceeds max stack size
+		recipe_pack.item1->stackSize    = 50;
+		asm_data.ingredientInv[0].count = 50;
+		EXPECT_FALSE(CanInsertAssemblyMachine(args));
+
+		// Under the max percentage that a slot can be filled
+		asm_data.ingredientInv[0].count = 1;
+		EXPECT_TRUE(CanInsertAssemblyMachine(args));
 	}
 
 	// ======================================================================

--- a/test/game/logic/item_logisticsTests.cpp
+++ b/test/game/logic/item_logisticsTests.cpp
@@ -389,16 +389,17 @@ namespace jactorio::game
 		DropOffParams args{logicData_, {recipe_pack.item1, 2000}, asm_data, data::Orientation::down};
 		EXPECT_TRUE(CanInsertAssemblyMachine(args));
 
-		// Exceeds the max percentage that a slot can be filled
+		// Exceeds the max ingredient count multiple that a slot can be filled
 		asm_data.ingredientInv[0].count = 2;
 		EXPECT_FALSE(CanInsertAssemblyMachine(args));
 
 		// Exceeds max stack size
+		recipe_pack.recipe.ingredients[0].second = 50;  // Requires 50, can only hold 50
 		recipe_pack.item1->stackSize    = 50;
 		asm_data.ingredientInv[0].count = 50;
 		EXPECT_FALSE(CanInsertAssemblyMachine(args));
 
-		// Under the max percentage that a slot can be filled
+		// Under the max ingredient count multiple that a slot can be filled
 		asm_data.ingredientInv[0].count = 1;
 		EXPECT_TRUE(CanInsertAssemblyMachine(args));
 	}

--- a/test/game/logic/item_logisticsTests.cpp
+++ b/test/game/logic/item_logisticsTests.cpp
@@ -403,7 +403,7 @@ namespace jactorio::game
 		/// Item which will be on transport segments from CreateTransportLine
 		data::Item lineItem_{};
 
-		// Creates a transport line 1 item on each side
+		/// \brief Creates a transport line with  1 item on each side, access segment_
 		data::TransportLineData CreateTransportLine(const data::Orientation orientation) {
 
 			const auto segment = std::make_shared<TransportSegment>(
@@ -420,6 +420,7 @@ namespace jactorio::game
 		}
 
 
+		/// \param orientation Orientation to line being picked up from
 		void PickupLine(const data::Orientation orientation,
 		                data::TransportLineData& line_data) {
 			constexpr int pickup_amount = 1;
@@ -644,6 +645,19 @@ namespace jactorio::game
 			EXPECT_EQ(segment_->right.lane.size(), 0);
 		}
 	}
+
+	TEST_F(InserterPickupTest, PickupTransportLineAlternativeSide) {
+		// If the preferred lane is available, inserter will attempt to pick up from other lane
+		auto line = CreateTransportLine(data::Orientation::up);
+
+		PickupLine(data::Orientation::up, line);
+		EXPECT_EQ(segment_->right.lane.size(), 0);
+
+		// Use alternative side
+		PickupLine(data::Orientation::up, line);
+		EXPECT_EQ(segment_->left.lane.size(), 0);
+	}
+
 
 	TEST_F(InserterPickupTest, PickupAssemblyMachine) {
 		data::PrototypeManager prototype_manager{};

--- a/test/game/logic/item_logisticsTests.cpp
+++ b/test/game/logic/item_logisticsTests.cpp
@@ -413,8 +413,8 @@ namespace jactorio::game
 			);
 
 			segment_ = segment.get();
-			segment_->InsertItem(false, 0.5, &lineItem_);
-			segment_->InsertItem(true, 0.5, &lineItem_);
+			segment_->InsertItem(false, 0.5, lineItem_);
+			segment_->InsertItem(true, 0.5, lineItem_);
 
 			return data::TransportLineData{segment};
 		}
@@ -644,6 +644,47 @@ namespace jactorio::game
 			PickupLine(data::Orientation::left, line);
 			EXPECT_EQ(segment_->right.lane.size(), 0);
 		}
+	}
+
+	TEST_F(InserterPickupTest, PickupTransportLineNonStraight) {
+		//
+		// ^
+		// | <--
+
+		const auto right = std::make_shared<TransportSegment>(
+			data::Orientation::right,
+			TransportSegment::TerminationType::straight,
+			2
+		);
+
+		const auto up = std::make_shared<TransportSegment>(
+			data::Orientation::up,
+			TransportSegment::TerminationType::bend_right,
+			2
+		);
+
+		const auto left = std::make_shared<TransportSegment>(
+			data::Orientation::left,
+			TransportSegment::TerminationType::bend_right,
+			2
+		);
+
+		left->targetSegment = up.get();
+		up->targetSegment = right.get();
+
+		data::TransportLineData line{left};
+		line.lineSegmentIndex = 1;
+
+
+		data::Item item;
+
+		left->AppendItem(true, 0.5 + 0.7, item);
+		PickupLine(data::Orientation::up, line);
+		EXPECT_EQ(left->left.lane.size(), 0);
+
+		left->AppendItem(false, 0.5 + 0.3, item);
+		PickupLine(data::Orientation::up, line);
+		EXPECT_EQ(left->right.lane.size(), 0);
 	}
 
 	TEST_F(InserterPickupTest, PickupTransportLineAlternativeSide) {

--- a/test/game/logic/item_logisticsTests.cpp
+++ b/test/game/logic/item_logisticsTests.cpp
@@ -539,15 +539,6 @@ namespace jactorio::game
 		{
 			auto line = CreateTransportLine(data::Orientation::up);
 
-			EXPECT_EQ(
-				GetPickupTransportBelt({
-					logicData_,
-					1, data::ToRotationDegree(180),
-					1, line, data::Orientation::right
-					}),
-				&lineItem_
-			);
-
 			PickupLine(data::Orientation::right, line);
 			EXPECT_EQ(segment_->right.lane.size(), 0);
 		}
@@ -691,10 +682,27 @@ namespace jactorio::game
 		// If the preferred lane is available, inserter will attempt to pick up from other lane
 		auto line = CreateTransportLine(data::Orientation::up);
 
+		EXPECT_EQ(
+			GetPickupTransportBelt({
+				logicData_,
+				1, data::ToRotationDegree(180),
+				1, line, data::Orientation::up
+				}),
+			&lineItem_
+		);
+
 		PickupLine(data::Orientation::up, line);
 		EXPECT_EQ(segment_->right.lane.size(), 0);
 
 		// Use alternative side
+		EXPECT_EQ(
+			GetPickupTransportBelt({
+				logicData_,
+				1, data::ToRotationDegree(180),
+				1, line, data::Orientation::up
+				}),
+			&lineItem_
+		);
 		PickupLine(data::Orientation::up, line);
 		EXPECT_EQ(segment_->left.lane.size(), 0);
 	}

--- a/test/game/logic/transport_line_controllerTests.cpp
+++ b/test/game/logic/transport_line_controllerTests.cpp
@@ -81,9 +81,9 @@ namespace jactorio::game
 		RegisterSegment({0, 5}, left_segment);
 
 		// Logic
-		left_segment->AppendItem(true, 0.f, &itemProto_);
-		left_segment->AppendItem(true, kItemSpacing, &itemProto_);
-		left_segment->AppendItem(true, kItemSpacing, &itemProto_);
+		left_segment->AppendItem(true, 0.f, itemProto_);
+		left_segment->AppendItem(true, kItemSpacing, itemProto_);
+		left_segment->AppendItem(true, kItemSpacing, itemProto_);
 
 		// 1 update
 		// first item moved to up segment
@@ -153,9 +153,9 @@ namespace jactorio::game
 		RegisterSegment({3, 0}, right_segment);
 
 		// Offset is distance from beginning, or previous item
-		up_segment->AppendItem(true, 0.f, &itemProto_);
-		up_segment->AppendItem(true, 1, &itemProto_);
-		up_segment->AppendItem(true, 1, &itemProto_);
+		up_segment->AppendItem(true, 0.f, itemProto_);
+		up_segment->AppendItem(true, 1, itemProto_);
+		up_segment->AppendItem(true, 1, itemProto_);
 		static_assert(kItemSpacing < 1);  // Tested positions would otherwise be invalid
 
 		// Logic
@@ -225,8 +225,8 @@ namespace jactorio::game
 		RegisterSegment({3, 0}, right_segment);
 
 		// Offset is distance from beginning, or previous item
-		up_segment->AppendItem(true, 0.f, &itemProto_);
-		up_segment->AppendItem(true, kItemSpacing, &itemProto_);
+		up_segment->AppendItem(true, 0.f, itemProto_);
+		up_segment->AppendItem(true, kItemSpacing, itemProto_);
 
 		// First item
 		TransportLineLogicUpdate(worldData_);
@@ -266,9 +266,9 @@ namespace jactorio::game
 
 		RegisterSegment({0, 0}, segment);
 
-		segment->AppendItem(true, 0.5f, &itemProto_);
-		segment->AppendItem(true, kItemSpacing, &itemProto_);
-		segment->AppendItem(true, kItemSpacing + 1.f, &itemProto_);
+		segment->AppendItem(true, 0.5f, itemProto_);
+		segment->AppendItem(true, kItemSpacing, itemProto_);
+		segment->AppendItem(true, kItemSpacing + 1.f, itemProto_);
 
 		// Will reach distance 0 after 0.5 / 0.01 updates
 		for (int i = 0; i < 50; ++i) {
@@ -338,11 +338,11 @@ namespace jactorio::game
 
 		// RIGHT LINE: 14 items can be fit on the right lane: (4 - 0.7) / kItemSpacing{0.25} = 13.2
 		for (int i = 0; i < 14; ++i) {
-			right_segment->AppendItem(false, 0.f, &itemProto_);
+			right_segment->AppendItem(false, 0.f, itemProto_);
 		}
 
 		// Items on up line should stop
-		up_segment->AppendItem(false, 0.f, &itemProto_);
+		up_segment->AppendItem(false, 0.f, itemProto_);
 
 		// WIll not move after an arbitrary number of updates
 		for (int i = 0; i < 34; ++i) {
@@ -367,11 +367,11 @@ namespace jactorio::game
 		RegisterSegment({2, 1}, left_segment);
 
 		// One item stopped, one still moving
-		left_segment->AppendItem(true, 0, &itemProto_);
+		left_segment->AppendItem(true, 0, itemProto_);
 		TransportLineLogicUpdate(worldData_);
 		EXPECT_EQ(left_segment.get()->left.index, 0);
 
-		left_segment->AppendItem(true, 2, &itemProto_);
+		left_segment->AppendItem(true, 2, itemProto_);
 		TransportLineLogicUpdate(worldData_);
 		EXPECT_EQ(left_segment.get()->left.index, 1);
 
@@ -421,11 +421,11 @@ namespace jactorio::game
 		// ======================================================================
 
 
-		left_segment->AppendItem(true, 1 - kItemSpacing + 0.01, &itemProto_);
+		left_segment->AppendItem(true, 1 - kItemSpacing + 0.01, itemProto_);
 
-		left_segment_2->AppendItem(true, 0, &itemProto_);
-		left_segment_2->AppendItem(true, 0.5, &itemProto_);
-		left_segment_2->AppendItem(true, 2, &itemProto_);
+		left_segment_2->AppendItem(true, 0, itemProto_);
+		left_segment_2->AppendItem(true, 0.5, itemProto_);
+		left_segment_2->AppendItem(true, 2, itemProto_);
 
 		TransportLineLogicUpdate(worldData_);
 
@@ -450,8 +450,8 @@ namespace jactorio::game
 
 		RegisterSegment({0, 0}, right_segment);
 
-		right_segment->AppendItem(true, 0.f, &itemProto_);
-		right_segment->AppendItem(true, 0.f, &itemProto_);  // Insert behind previous item
+		right_segment->AppendItem(true, 0.f, itemProto_);
+		right_segment->AppendItem(true, 0.f, itemProto_);  // Insert behind previous item
 
 		// Check that second item has a minimum distance of kItemSpacing
 		EXPECT_FLOAT_EQ(right_segment->left.lane[0].first.getAsDouble(), 0.f);
@@ -485,7 +485,7 @@ namespace jactorio::game
 		RegisterSegment({0, 0}, up_segment_1);
 		RegisterSegment({0, 1}, up_segment_2);
 
-		up_segment_2->AppendItem(true, 0.05, &itemProto_);
+		up_segment_2->AppendItem(true, 0.05, itemProto_);
 		EXPECT_FLOAT_EQ(up_segment_2->left.backItemDistance.getAsDouble(), 0.05);
 
 		TransportLineLogicUpdate(worldData_);
@@ -509,14 +509,14 @@ namespace jactorio::game
 
 		// ======================================================================
 		// Fill the first segment up to 4 items
-		up_segment_1->AppendItem(true, 0, &itemProto_);
-		up_segment_1->AppendItem(true, 0, &itemProto_);
-		up_segment_1->AppendItem(true, 0, &itemProto_);
+		up_segment_1->AppendItem(true, 0, itemProto_);
+		up_segment_1->AppendItem(true, 0, itemProto_);
+		up_segment_1->AppendItem(true, 0, itemProto_);
 		EXPECT_FLOAT_EQ(up_segment_1->left.backItemDistance.getAsDouble(), 0.75);
 
 
 		// Will not enter since segment 1 is full
-		up_segment_2->AppendItem(true, 0.05, &itemProto_);
+		up_segment_2->AppendItem(true, 0.05, itemProto_);
 		TransportLineLogicUpdate(worldData_);
 		TransportLineLogicUpdate(worldData_);
 		TransportLineLogicUpdate(worldData_);
@@ -552,8 +552,8 @@ namespace jactorio::game
 		RegisterSegment({3, 0}, segment_2);
 
 		// Insert item on left + right side
-		segment_2->AppendItem(true, 0.02f, &itemProto_);
-		segment_2->AppendItem(false, 0.02f, &itemProto_);
+		segment_2->AppendItem(true, 0.02f, itemProto_);
+		segment_2->AppendItem(false, 0.02f, itemProto_);
 
 		// Travel to the next belt in 0.02 / 0.01 + 1 updates
 		for (int i = 0; i < 3; ++i) {
@@ -604,8 +604,8 @@ namespace jactorio::game
 
 		// Insert items
 		for (int i = 0; i < 3; ++i) {
-			right_segment->AppendItem(true, 0.f, &itemProto_);
-			right_segment->AppendItem(false, 0.f, &itemProto_);
+			right_segment->AppendItem(true, 0.f, itemProto_);
+			right_segment->AppendItem(false, 0.f, itemProto_);
 		}
 
 		// Logic tests
@@ -707,8 +707,8 @@ namespace jactorio::game
 
 		// Insert items
 		for (int i = 0; i < 3; ++i) {
-			left_segment->AppendItem(true, 0.f, &itemProto_);
-			left_segment->AppendItem(false, 0.f, &itemProto_);
+			left_segment->AppendItem(true, 0.f, itemProto_);
+			left_segment->AppendItem(false, 0.f, itemProto_);
 		}
 
 		// Logic tests
@@ -802,7 +802,7 @@ namespace jactorio::game
 		// Left lane
 
 
-		down_segment->AppendItem(true, 0, &itemProto_);
+		down_segment->AppendItem(true, 0, itemProto_);
 
 		TransportLineLogicUpdate(worldData_);
 
@@ -817,7 +817,7 @@ namespace jactorio::game
 
 		left_segment->right.lane.clear();
 
-		down_segment->AppendItem(false, 0, &itemProto_);
+		down_segment->AppendItem(false, 0, itemProto_);
 
 		TransportLineLogicUpdate(worldData_);
 
@@ -842,7 +842,7 @@ namespace jactorio::game
 		// Left lane
 
 
-		up_segment->AppendItem(true, 0, &itemProto_);
+		up_segment->AppendItem(true, 0, itemProto_);
 
 		TransportLineLogicUpdate(worldData_);
 
@@ -856,7 +856,7 @@ namespace jactorio::game
 
 		left_segment->left.lane.clear();
 
-		up_segment->AppendItem(false, 0, &itemProto_);
+		up_segment->AppendItem(false, 0, itemProto_);
 
 		TransportLineLogicUpdate(worldData_);
 
@@ -893,7 +893,7 @@ namespace jactorio::game
 		// ======================================================================
 		// Left
 
-		right_segment->AppendItem(true, 0, &itemProto_);
+		right_segment->AppendItem(true, 0, itemProto_);
 
 		TransportLineLogicUpdate(worldData_);
 
@@ -903,7 +903,7 @@ namespace jactorio::game
 
 		// Right
 
-		right_segment->AppendItem(false, 0, &itemProto_);
+		right_segment->AppendItem(false, 0, itemProto_);
 
 		TransportLineLogicUpdate(worldData_);
 

--- a/test/game/logic/transport_segmentTests.cpp
+++ b/test/game/logic/transport_segmentTests.cpp
@@ -31,15 +31,15 @@ namespace jactorio::game
 		// THe entire transport line is compressed with items, cannot insert
 
 		// At spacing of 0.25, 4 items per segment
-		segment_->AppendItem(true, 0.f, itemProto_.get());
-		segment_->AppendItem(true, kItemSpacing, itemProto_.get());
-		segment_->AppendItem(true, kItemSpacing, itemProto_.get());
-		segment_->AppendItem(true, kItemSpacing, itemProto_.get());
+		segment_->AppendItem(true, 0.f, *itemProto_);
+		segment_->AppendItem(true, kItemSpacing, *itemProto_);
+		segment_->AppendItem(true, kItemSpacing, *itemProto_);
+		segment_->AppendItem(true, kItemSpacing, *itemProto_);
 
-		segment_->AppendItem(true, kItemSpacing, itemProto_.get());
-		segment_->AppendItem(true, kItemSpacing, itemProto_.get());
-		segment_->AppendItem(true, kItemSpacing, itemProto_.get());
-		segment_->AppendItem(true, kItemSpacing, itemProto_.get());
+		segment_->AppendItem(true, kItemSpacing, *itemProto_);
+		segment_->AppendItem(true, kItemSpacing, *itemProto_);
+		segment_->AppendItem(true, kItemSpacing, *itemProto_);
+		segment_->AppendItem(true, kItemSpacing, *itemProto_);
 
 		// Location 1.75 tiles from beginning of transport line is filled
 		EXPECT_FALSE(segment_->CanInsert(true,
@@ -56,10 +56,10 @@ namespace jactorio::game
 		// Insert into a gap between 1 and 1.5
 		// Is wide enough for the item (item_width - kItemSpacing) to fit there
 
-		segment_->AppendItem(false, 0.f, itemProto_.get());
-		segment_->AppendItem(false, 1.f, itemProto_.get());
+		segment_->AppendItem(false, 0.f, *itemProto_);
+		segment_->AppendItem(false, 1.f, *itemProto_);
 		// Items can be inserted in this 0.5 gap
-		segment_->AppendItem(false, 0.5f, itemProto_.get());
+		segment_->AppendItem(false, 0.5f, *itemProto_);
 
 
 		// Overlaps with the item at 1 by 0.01
@@ -84,11 +84,11 @@ namespace jactorio::game
 		bool result = segment_->CanInsert(true, offset);  // Ok, Offset can be 0, is first item
 		EXPECT_TRUE(result);
 
-		segment_->AppendItem(true, 0, itemProto_.get());
+		segment_->AppendItem(true, 0, *itemProto_);
 		result = segment_->CanInsert(true, offset);  // Not ok, offset changed to kItemSpacing
 		EXPECT_FALSE(result);
 
-		segment_->AppendItem(true, 0, itemProto_.get());
+		segment_->AppendItem(true, 0, *itemProto_);
 		result = segment_->CanInsert(true, offset);  // Not ok, offset changed to kItemSpacing
 		EXPECT_FALSE(result);
 	}
@@ -98,7 +98,7 @@ namespace jactorio::game
 		segment_->itemOffset = 1;
 		const TransportLineOffset offset{0.f};
 
-		segment_->AppendItem(true, 0, itemProto_.get());
+		segment_->AppendItem(true, 0, *itemProto_);
 		const bool result = segment_->CanInsertAbs(true, offset);  // Ok, offset (0) + itemOffset (1) = 1 
 		EXPECT_TRUE(result);
 	}
@@ -111,8 +111,8 @@ namespace jactorio::game
 		EXPECT_FALSE(segment_->left.IsActive());
 		EXPECT_FALSE(segment_->right.IsActive());
 
-		segment_->AppendItem(false, 0.f, itemProto_.get());
-		segment_->AppendItem(true, 0.f, itemProto_.get());
+		segment_->AppendItem(false, 0.f, *itemProto_);
+		segment_->AppendItem(true, 0.f, *itemProto_);
 
 		// Has items, now active
 		EXPECT_TRUE(segment_->left.IsActive());
@@ -133,16 +133,16 @@ namespace jactorio::game
 		);
 
 		// Offset is from the beginning of the transport line OR the previous item if it exists
-		line_segment->AppendItem(true, 1.3, itemProto_.get());
+		line_segment->AppendItem(true, 1.3, *itemProto_);
 		EXPECT_FLOAT_EQ(line_segment.get()->left.lane[0].first.getAsDouble(), 1.3);
 
-		line_segment->AppendItem(true, 1.2, itemProto_.get());
+		line_segment->AppendItem(true, 1.2, *itemProto_);
 		EXPECT_FLOAT_EQ(line_segment.get()->left.lane[1].first.getAsDouble(), 1.2);
 
-		line_segment->AppendItem(true, 1.5, itemProto_.get());
+		line_segment->AppendItem(true, 1.5, *itemProto_);
 		EXPECT_FLOAT_EQ(line_segment.get()->left.lane[2].first.getAsDouble(), 1.5);
 
-		line_segment->AppendItem(true, 0.5, itemProto_.get());
+		line_segment->AppendItem(true, 0.5, *itemProto_);
 		EXPECT_FLOAT_EQ(line_segment.get()->left.lane[3].first.getAsDouble(), 0.5);
 	}
 
@@ -156,13 +156,13 @@ namespace jactorio::game
 			5
 		);
 
-		line_segment->AppendItem(true, 0, itemProto_.get());  // Ok, Offset can be 0, is first item
+		line_segment->AppendItem(true, 0, *itemProto_);  // Ok, Offset can be 0, is first item
 		EXPECT_FLOAT_EQ(line_segment.get()->left.lane[0].first.getAsDouble(), 0);
 
-		line_segment->AppendItem(true, 0, itemProto_.get());  // Not ok, offset changed to kItemSpacing
+		line_segment->AppendItem(true, 0, *itemProto_);  // Not ok, offset changed to kItemSpacing
 		EXPECT_FLOAT_EQ(line_segment.get()->left.lane[1].first.getAsDouble(), jactorio::game::kItemSpacing);
 
-		line_segment->AppendItem(true, 0, itemProto_.get());  // Not ok, offset changed to kItemSpacing
+		line_segment->AppendItem(true, 0, *itemProto_);  // Not ok, offset changed to kItemSpacing
 		EXPECT_FLOAT_EQ(line_segment.get()->left.lane[2].first.getAsDouble(), jactorio::game::kItemSpacing);
 	}
 
@@ -177,26 +177,26 @@ namespace jactorio::game
 
 		// Offset is ALWAYS from the beginning of the transport line
 
-		line_segment->InsertItem(true, 1.2, itemProto_.get());
+		line_segment->InsertItem(true, 1.2, *itemProto_);
 		EXPECT_FLOAT_EQ(line_segment.get()->left.lane[0].first.getAsDouble(), 1.2);  // < 1.2
 
 		// Should be sorted by items closest to the end of the segment
-		line_segment->InsertItem(true, 2.5, itemProto_.get());
+		line_segment->InsertItem(true, 2.5, *itemProto_);
 		EXPECT_FLOAT_EQ(line_segment.get()->left.lane[0].first.getAsDouble(), 1.2);  // 1.2
 		EXPECT_FLOAT_EQ(line_segment.get()->left.lane[1].first.getAsDouble(), 1.3);  // < 2.5
 
-		line_segment->InsertItem(true, 0.5, itemProto_.get());
+		line_segment->InsertItem(true, 0.5, *itemProto_);
 		EXPECT_FLOAT_EQ(line_segment.get()->left.lane[0].first.getAsDouble(), 0.5);  // < 0.5
 		EXPECT_FLOAT_EQ(line_segment.get()->left.lane[1].first.getAsDouble(), 0.7);  // 1.2
 		EXPECT_FLOAT_EQ(line_segment.get()->left.lane[2].first.getAsDouble(), 1.3);  // 2.5
 
-		line_segment->InsertItem(true, 0.1, itemProto_.get());
+		line_segment->InsertItem(true, 0.1, *itemProto_);
 		EXPECT_FLOAT_EQ(line_segment.get()->left.lane[0].first.getAsDouble(), 0.1);  // < 0.1
 		EXPECT_FLOAT_EQ(line_segment.get()->left.lane[1].first.getAsDouble(), 0.4);  // 0.5
 		EXPECT_FLOAT_EQ(line_segment.get()->left.lane[2].first.getAsDouble(), 0.7);  // 1.2
 		EXPECT_FLOAT_EQ(line_segment.get()->left.lane[3].first.getAsDouble(), 1.3);  // 2.5
 
-		line_segment->InsertItem(true, 1.8, itemProto_.get());
+		line_segment->InsertItem(true, 1.8, *itemProto_);
 		EXPECT_FLOAT_EQ(line_segment.get()->left.lane[0].first.getAsDouble(), 0.1);  // 0.1
 		EXPECT_FLOAT_EQ(line_segment.get()->left.lane[1].first.getAsDouble(), 0.4);  // 0.5
 		EXPECT_FLOAT_EQ(line_segment.get()->left.lane[2].first.getAsDouble(), 0.7);  // 1.2
@@ -214,10 +214,10 @@ namespace jactorio::game
 
 		// Offset is ALWAYS from the beginning of the transport line + itemOffset
 
-		line_segment->InsertItemAbs(true, 1.2, itemProto_.get());
+		line_segment->InsertItemAbs(true, 1.2, *itemProto_);
 		EXPECT_FLOAT_EQ(line_segment.get()->left.lane[0].first.getAsDouble(), 3.2);
 
-		line_segment->InsertItemAbs(true, 1.5, itemProto_.get());
+		line_segment->InsertItemAbs(true, 1.5, *itemProto_);
 		EXPECT_FLOAT_EQ(line_segment.get()->left.lane[0].first.getAsDouble(), 3.2);
 		EXPECT_FLOAT_EQ(line_segment.get()->left.lane[1].first.getAsDouble(), 0.3);  // 1.5
 	}
@@ -232,13 +232,13 @@ namespace jactorio::game
 
 		// Offset is ALWAYS from the beginning of the transport line
 		{
-			const bool result = line_segment->TryInsertItem(true, 1.2, itemProto_.get());
+			const bool result = line_segment->TryInsertItem(true, 1.2, *itemProto_);
 			ASSERT_TRUE(result);
 			EXPECT_FLOAT_EQ(line_segment.get()->left.lane[0].first.getAsDouble(), 1.2);
 		}
 		{
 			// Too close
-			const bool result = line_segment->TryInsertItem(true, 1.3, itemProto_.get());
+			const bool result = line_segment->TryInsertItem(true, 1.3, *itemProto_);
 			ASSERT_FALSE(result);
 		}
 
@@ -247,7 +247,7 @@ namespace jactorio::game
 		line_segment->left.index = 999;
 
 		{
-			const bool result = line_segment->TryInsertItem(true, 0.5, itemProto_.get());
+			const bool result = line_segment->TryInsertItem(true, 0.5, *itemProto_);
 			ASSERT_TRUE(result);
 			EXPECT_FLOAT_EQ(line_segment.get()->left.lane[0].first.getAsDouble(), 0.5);
 			EXPECT_FLOAT_EQ(line_segment.get()->left.lane[1].first.getAsDouble(), 0.7);  // 1.2
@@ -268,20 +268,20 @@ namespace jactorio::game
 
 
 		// Appending
-		line_segment->AppendItem(true, 1.2, itemProto_.get());
+		line_segment->AppendItem(true, 1.2, *itemProto_);
 		EXPECT_FLOAT_EQ(line_segment->left.backItemDistance.getAsDouble(), 1.2f);
 
-		line_segment->AppendItem(true, 3, itemProto_.get());
+		line_segment->AppendItem(true, 3, *itemProto_);
 		EXPECT_FLOAT_EQ(line_segment->left.backItemDistance.getAsDouble(), 4.2f);
 
-		line_segment->AppendItem(true, 1.8, itemProto_.get());
+		line_segment->AppendItem(true, 1.8, *itemProto_);
 		EXPECT_FLOAT_EQ(line_segment->left.backItemDistance.getAsDouble(), 6.f);
 
 		// Inserting (Starting at 6.f)
-		line_segment->InsertItem(true, 7, itemProto_.get());
+		line_segment->InsertItem(true, 7, *itemProto_);
 		EXPECT_FLOAT_EQ(line_segment->left.backItemDistance.getAsDouble(), 7.f);
 
-		line_segment->InsertItem(true, 2, itemProto_.get());
+		line_segment->InsertItem(true, 2, *itemProto_);
 		EXPECT_FLOAT_EQ(line_segment->left.backItemDistance.getAsDouble(), 7.f);  // Unchanged
 
 		EXPECT_FLOAT_EQ(line_segment->right.backItemDistance.getAsDouble(), 0.f);
@@ -299,20 +299,20 @@ namespace jactorio::game
 
 
 		// Appending
-		line_segment->AppendItem(false, 1.2, itemProto_.get());
+		line_segment->AppendItem(false, 1.2, *itemProto_);
 		EXPECT_FLOAT_EQ(line_segment->right.backItemDistance.getAsDouble(), 1.2f);
 
-		line_segment->AppendItem(false, 3, itemProto_.get());
+		line_segment->AppendItem(false, 3, *itemProto_);
 		EXPECT_FLOAT_EQ(line_segment->right.backItemDistance.getAsDouble(), 4.2f);
 
-		line_segment->AppendItem(false, 1.8, itemProto_.get());
+		line_segment->AppendItem(false, 1.8, *itemProto_);
 		EXPECT_FLOAT_EQ(line_segment->right.backItemDistance.getAsDouble(), 6.f);
 
 		// Inserting (Starting at 6.f)
-		line_segment->InsertItem(false, 7, itemProto_.get());
+		line_segment->InsertItem(false, 7, *itemProto_);
 		EXPECT_FLOAT_EQ(line_segment->right.backItemDistance.getAsDouble(), 7.f);
 
-		line_segment->InsertItem(false, 2, itemProto_.get());
+		line_segment->InsertItem(false, 2, *itemProto_);
 		EXPECT_FLOAT_EQ(line_segment->right.backItemDistance.getAsDouble(), 7.f);  // Unchanged
 
 		EXPECT_FLOAT_EQ(line_segment->left.backItemDistance.getAsDouble(), 0.f);
@@ -343,24 +343,39 @@ namespace jactorio::game
 		}
 	}
 
+	TEST_F(TransportSegmentTest, GetItem) {
+		auto get_item = [&]() {  // true is an item is found
+			// Valid range is 1.3 and 1.7 inclusive
+			return segment_->GetItem(true, 1.5).second.second != nullptr;
+		};
+		
+		segment_->AppendItem(true, 0.5, *itemProto_);
+		segment_->AppendItem(true, 0.5, *itemProto_);   // 1.00
+		segment_->AppendItem(true, 0.29, *itemProto_);  // 1.29
+		EXPECT_FALSE(get_item());
+
+		segment_->AppendItem(true, 0.42, *itemProto_);  // 1.71
+		EXPECT_FALSE(get_item());
+	}
+
 	TEST_F(TransportSegmentTest, TryPopItem) {
-		EXPECT_EQ(segment_->TryPopItemAbs(true, 0.25), nullptr);
-		EXPECT_EQ(segment_->TryPopItemAbs(false, 0.25), nullptr);
+		EXPECT_EQ(segment_->TryPopItem(true, 0.25), nullptr);
+		EXPECT_EQ(segment_->TryPopItem(false, 0.25), nullptr);
 
 		// Pop off appended item
-		segment_->AppendItem(true, 0.3, itemProto_.get());
+		segment_->AppendItem(true, 0.3, *itemProto_);
 
-		EXPECT_EQ(segment_->TryPopItemAbs(true, 0.4, 0.1), itemProto_.get());
+		EXPECT_EQ(segment_->TryPopItem(true, 0.4, 0.1), itemProto_.get());
 		ASSERT_TRUE(segment_->left.lane.empty());
 
 		//
 
 		data::Item item2{};
-		segment_->AppendItem(true, 0.1, itemProto_.get());
-		segment_->AppendItem(true, 0.8, &item2);  // 0.9
-		segment_->AppendItem(true, 0.9, itemProto_.get());  // 1.8
+		segment_->AppendItem(true, 0.1, *itemProto_);
+		segment_->AppendItem(true, 0.8, item2);  // 0.9
+		segment_->AppendItem(true, 0.9, *itemProto_);  // 1.8
 
-		EXPECT_EQ(segment_->TryPopItemAbs(true, 0.9, 0.7), &item2);
+		EXPECT_EQ(segment_->TryPopItem(true, 0.9, 0.7), &item2);
 		ASSERT_EQ(segment_->left.lane.size(), 2);
 
 		// Should preserve spacing

--- a/test/game/world/world_dataTests.cpp
+++ b/test/game/world/world_dataTests.cpp
@@ -200,6 +200,14 @@ namespace jactorio::game
 		                         {42, 0},
 		                         ChunkTile::ChunkLayer::entity);
 		EXPECT_EQ(worldData_.LogicGetChunks().size(), 1);
+
+		
+		// Registering same position does nothing
+		worldData_.LogicRegister(Chunk::LogicGroup::inserter,
+		                         {42, 0},
+		                         ChunkTile::ChunkLayer::entity);
+		EXPECT_EQ((*worldData_.LogicGetChunks().begin())
+				  ->GetLogicGroup(Chunk::LogicGroup::inserter).size(), 2);
 	}
 
 	TEST_F(WorldDataTest, LogicRemove) {


### PR DESCRIPTION
## Features
- Inserters have arms with the item they are currently holding
- Inserters will only pick up items that it can drop off
- Inserters in assembly machines will only fill to amount required for crafting * 2
- Inserters can pick up from both lanes of a transport segment

## Bugfixes
- Fixed inserters not always picking up / dropping items at the center of a transport segment lane
- Fixed inserter behavior fluctuating depending on order in logic updates
