### PR TITLE
Improve/lto all translation units

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -12,6 +12,9 @@ include(CheckIPOSupported)
 set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
+set(CMAKE_POLICY_DEFAULT_CMP0069 NEW) # Enable IPO for all
+
+
 project("jactorio")
 
 option(JACTORIO_BUILD_TESTS "JACTORIO_BUILD_TESTS")
@@ -35,8 +38,8 @@ function(jactorio_copy_data_files)
 
 	log_msg("Copying files to output directory: ${CMAKE_CURRENT_BINARY_DIR}/${JACTORIO_DATA_FOLDER}")
 
-	file(GLOB_RECURSE 
-		DATA_FILES 
+	file(GLOB_RECURSE
+		DATA_FILES
 		RELATIVE ${PROJECT_SOURCE_DIR}
 		${PROJECT_SOURCE_DIR}/${JACTORIO_DATA_FOLDER}/*
 	)
@@ -64,8 +67,8 @@ ELSEIF(CMAKE_BUILD_TYPE MATCHES Release OR CMAKE_BUILD_TYPE MATCHES RelWithDebIn
 	check_ipo_supported(RESULT result)
 
 	if(result)
-		log_msg("IPO: Available")
-		set(JACTORIO_INTERPROCEDURAL_OPTIMIZATION TRUE)
+        log_msg("IPO: Available, Enabled")
+        set(CMAKE_INTERPROCEDURAL_OPTIMIZATION TRUE)
 	else()
 		log_msg("IPO: ~Unavailable")
 	endif()

--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -1,6 +1,4 @@
 # Includes dependencies
-cmake_minimum_required(VERSION 3.8)
-
 log_msg("")
 log_msg("[ Jactorio lib ]")
 

--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -34,6 +34,12 @@ validate_dependency(backward-cpp)
 validate_dependency(cereal)
 
 
+# SDL, fixes unresolved symbols to memset, memcpy, __chkstk when using /GL (Whole program optimization)
+if (MSVC)
+	list(APPEND EXTRA_LIBS vcruntime msvcrt)
+endif()
+
+
 # Ones which need to be built
 add_subdirectory("glew-cmake")
 add_subdirectory("pybind11")

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,9 +1,4 @@
-﻿# CMakeList.txt : CMake project for jactorio, include source and define
-# project specific logic here.
-#
-cmake_minimum_required(VERSION 3.9)
-
-log_msg("")
+﻿log_msg("")
 log_msg("[   Jactorio   ]")
 
 set(CMAKE_RUNTIME_OUTPUT_DIRECTORY_DEBUG ${CMAKE_CURRENT_BINARY_DIR})
@@ -121,33 +116,17 @@ IF (CMAKE_SYSTEM_NAME MATCHES Windows)
 ENDIF ()
 # ======================================== END Lib files .cpp
 
-IF (JACTORIO_BUILD_TESTS OR NOT JACTORIO_INTERPROCEDURAL_OPTIMIZATION)
-    # library linked to for tests
-    add_library(jactorioBase
-            ${JACTORIO_SRC_FILES}
-            ${JACTORIO_LIB_BUILD_FILES}
-            )
-    target_include_directories(jactorioBase PUBLIC ${JACTORIO_INCLUDE_FILES})
-    target_link_libraries(jactorioBase jactorioLib)
-ENDIF ()
+# base linked to for tests
+add_library(jactorioBase
+        ${JACTORIO_SRC_FILES}
+        ${JACTORIO_LIB_BUILD_FILES}
+        )
+target_include_directories(jactorioBase PUBLIC ${JACTORIO_INCLUDE_FILES})
+target_link_libraries(jactorioBase jactorioLib)
 
 
 # Jactorio Executable
-IF (JACTORIO_INTERPROCEDURAL_OPTIMIZATION)
-    # Must compile sources separately for IPO
-    add_executable(jactorio
-            ${JACTORIO_DIR}/jactorio.cpp
-            ${JACTORIO_SRC_FILES}
-            ${JACTORIO_LIB_BUILD_FILES}
-            )
-    set_property(TARGET jactorio PROPERTY INTERPROCEDURAL_OPTIMIZATION TRUE)
-
-    target_link_libraries(jactorio jactorioLib)
-    target_include_directories(jactorio PUBLIC ${JACTORIO_INCLUDE_FILES})
-ELSE ()
-    add_executable(jactorio
-            ${JACTORIO_DIR}/jactorio.cpp
-            )
-    target_link_libraries(jactorio jactorioBase)
-ENDIF ()
-
+add_executable(jactorio
+        ${JACTORIO_DIR}/jactorio.cpp
+        )
+target_link_libraries(jactorio jactorioBase)

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -135,3 +135,11 @@ target_include_directories(jactorioTest
 	PUBLIC
 	${JACTORIO_TEST_DIR}
 )
+
+
+# MSVC complains that it introduced reference to symbol _fltused which was previously compiled with /GL
+# This can be ignored since _fltused just means that floating point was used
+# https://stackoverflow.com/questions/1583196
+if (MSVC)
+	target_link_options(jactorioTest PRIVATE /INCLUDE:_fltused)
+endif()

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -1,8 +1,3 @@
-# CMakeList.txt : CMake project for jactorio TESTS, include source and define
-# project specific logic here.
-#
-cmake_minimum_required (VERSION 3.8)
-
 log_msg("")
 log_msg("[Jactorio test ]")
 
@@ -129,11 +124,11 @@ set(JACTORIO_TEST_FILES
 # ======================================== END Test files .cpp
 
 # Test executable
-add_executable(jactorioTest 
+add_executable(jactorioTest
 	${JACTORIO_TEST_DIR}/jactorioTests.cpp
 	${JACTORIO_TEST_FILES}
 )
-target_link_libraries(jactorioTest 
+target_link_libraries(jactorioTest
 	gtest_main jactorioBase
 )
 target_include_directories(jactorioTest


### PR DESCRIPTION
Enabled IPO for all translation units (Whole program optimization, Link time optimization)

Avoids having to recompile src files without IPO for tests as test were previously build without IPO, thus they could not be linked to the src files built with IPO.

May also improve performance as external libraries are also optimized with IPO.
