### PR TITLE
Change shebang from sh to bash

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 if [[ -z "$1" ]] || [[ "$1" != "Debug"  &&  "$1" != "Release" &&  "$1" != "RelWithDebInfo" ]]; then
     echo "Invalid build type"


### PR DESCRIPTION
Issue #35 was struggling running build.sh due to the misleading shebang.

They would have still run into the same issue due to them manually specifying `sh` with `sh build.sh`, but changing the shebang:
1. Makes it clear for anyone looking at the first line of the file what the intended shell is
2. Allows `./build.sh` to work, whereas it did not before